### PR TITLE
Graphviz may not be available during tests

### DIFF
--- a/txtorcon/test/test_fsm.py
+++ b/txtorcon/test/test_fsm.py
@@ -3,8 +3,10 @@ import txtorcon.spaghetti
 from txtorcon.spaghetti import *
 from twisted.trial import unittest
 
-import tempfile
 import os
+import subprocess
+import tempfile
+
 
 class FsmTests(unittest.TestCase):
 
@@ -18,14 +20,10 @@ class FsmTests(unittest.TestCase):
         not really 'testing' here, going for code-coverage to simply
         call the __str__ methods to ensure they don't explode
         """
-        
+
         a = State("A")
         b = State("B")
-        def match(x):
-            pass
-        def action(x):
-            pass
-        tran = Transition(b, match, action)
+        tran = Transition(b, lambda x: None, lambda x: None)
         a.add_transition(tran)
         fsm = FSM([a, b])
         x = str(fsm)
@@ -38,16 +36,16 @@ class FsmTests(unittest.TestCase):
     def test_no_init(self):
         fsm = FSM([])
         self.assertRaises(Exception, fsm.process, "")
-    
+
     def test_no_init_ctor(self):
         fsm = FSM([])
         idle = State("I")
         foo = str(idle)
-        
+
         fsm.add_state(idle)
         self.assertWarns(RuntimeWarning, "No next state", txtorcon.spaghetti.__file__,
                          fsm.process, "")
-    
+
     def test_no_matcher(self):
         idle = State("I")
         other = State("O")
@@ -58,33 +56,41 @@ class FsmTests(unittest.TestCase):
 
     def test_bad_transition(self):
         self.assertRaises(Exception, Transition, None, self.match, None)
-        
+
     def test_dotty(self):
         idle = State("I")
         fsm = FSM([idle])
         self.assertTrue(idle.dotty() in fsm.dotty())
         self.assertTrue("digraph" in fsm.dotty())
         fname = tempfile.mktemp() + '.dot'
-        open(fname, 'w').write(fsm.dotty())
-        self.assertEqual(os.system("dot %s > /dev/null" % fname), 0)
-        os.unlink(fname)
+        try:
+            f = open(fname, 'w')
+            f.write(fsm.dotty())
+            f.close()
+            try:
+                subprocess.check_output(("dot", fname))
+            except OSError:
+                # Graphviz probably not available; skip
+                return
+            except subprocess.CalledProcessError, e:
+                self.fail(str(e))
+        finally:
+            os.unlink(fname)
 
     def test_handler_state(self):
         idle = State("I")
         cmd = State("C")
-        def handler(x):
-            return idle
 
         idle.add_transitions([Transition(cmd,
                                          self.match,
-                                         handler)])
-        
+                                         lambda x: idle)])
+
         fsm = FSM([idle, cmd])
         self.commands = []
         self.assertEqual(fsm.state, idle)
         fsm.process("250 OK\n")
         self.assertEqual(fsm.state, idle)
-    
+
     def test_simple_machine(self):
         idle = State("I")
         cmd = State("C")
@@ -92,7 +98,7 @@ class FsmTests(unittest.TestCase):
         idle.add_transitions([Transition(cmd,
                                          self.match,
                                          None)])
-        
+
         fsm = FSM([idle, cmd])
         self.commands = []
         self.assertEqual(fsm.state, idle)
@@ -100,4 +106,4 @@ class FsmTests(unittest.TestCase):
         self.assertEqual(fsm.state, cmd)
 
     def doCommand(self, data):
-        print "transition:",data
+        print "transition:", data


### PR DESCRIPTION
Hi,

a small change to test_fsm.py that handles graphviz not being available while testing. Instead of bailing out with an error, we test as much as be can and succeed the test even if dot is not available. This allows the test-suite to run to completion without having to declare graphviz a build-time requirement.

The usage of os.system is replaced by subprocess.check_output; the tempfile was neither flushed nor closed, which may cause dot to fail in case the file was not synced to the fs; we also make sure the tempfile is unlinked even if the test fails.

Also some small whitespace/pep8 fixes and cleanups to that file.
