### PR TITLE
Remove unnecessary line in MANIFEST.in for docs/avatar.png.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include scripts/*.py
 include docs/Makefile
 include docs/apilinks_sphinxext.py
 include docs/conf.py
-include docs/avatar.png
 include docs/*.rst
 include docs/_static/*
 include examples/*


### PR DESCRIPTION
The buildbot for ooni-backend was showing:

```
   Downloading/unpacking txtorcon>=0.7 (from -r .requirements.travis (line 21))
   Downloading txtorcon-0.7.tar.gz (128kB): 128kB downloaded
   Running setup.py egg_info for package txtorcon
   warning: no files found matching 'docs/avatar.png'
```
