### PR TITLE
Fixed two tests, fixes for PyP

### DIFF
--- a/txtorcon/test/test_torconfig.py
+++ b/txtorcon/test/test_torconfig.py
@@ -519,8 +519,10 @@ OK''')
         d = tempfile.mkdtemp()
 
         try:
-            open(os.path.join(d, 'hostname'), 'w').write('public')
-            open(os.path.join(d, 'private_key'), 'w').write('private')
+            with open(os.path.join(d, 'hostname'), 'w') as f:
+                f.write('public')
+            with open(os.path.join(d, 'private_key'), 'w') as f:
+                f.write('private')
 
             conf = TorConfig(self.protocol)
             hs = HiddenService(conf, d, [])

--- a/txtorcon/test/test_torcontrolprotocol.py
+++ b/txtorcon/test/test_torcontrolprotocol.py
@@ -67,7 +67,8 @@ class AuthenticationTests(unittest.TestCase):
         self.assertEqual(self.transport.value(), 'PROTOCOLINFO 1\r\n')
         self.transport.clear()
         cookie_data = 'cookiedata!cookiedata!cookiedata'
-        open('authcookie', 'w').write(cookie_data)
+        with open('authcookie', 'w') as f:
+            f.write(cookie_data)
         self.send('250-PROTOCOLINFO 1')
         self.send('250-AUTH METHODS=COOKIE,HASHEDPASSWORD COOKIEFILE="authcookie"')
         self.send('250-VERSION Tor="0.2.2.34"')

--- a/txtorcon/torstate.py
+++ b/txtorcon/torstate.py
@@ -693,7 +693,7 @@ class TorState(object):
             is_named = False
             if len(routerid) > 41:
                 nick = routerid[42:]
-                is_named = routerid[41] is '='
+                is_named = routerid[41] == '='
             router.update(nick, hashFromHexId(idhash), '0' * 27, 'unknown',
                           'unknown', '0', '0')
             router.name_is_unique = is_named


### PR DESCRIPTION
Hi,

here are two fixes for unflushed buffers leading to a race condition on slow IO, causing unittests to fail.
There was also a subtle bug in torstate.py due to a identity-comparison against a string: Comparisons against immutable objects (such as a string) based on identity ("foo is bar") usually get you more than you ask for. Due to the way PyPy handles the situation, a comparison fails - strings are equal but not identical - and hidden services are never considered having a unique name...

edit: there is a discussion about the above right now at http://mail.python.org/pipermail/pypy-dev/2013-May/011299.html

Fixing the above, the test-suite now passes on Linux 3.0.8+ armv7l using PyPy 2.0 alpha
