### PR TITLE
On issue #36

### DIFF
--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -80,7 +80,7 @@ def find_tor_binary(globs=('/usr/sbin/', '/usr/bin/',
     # Try to find the tor executable using the shell
     if system_tor:
         try:
-            proc = subprocess.Popen(('type -p tor', ), executable='/bin/bash',
+            proc = subprocess.Popen(('which tor'),
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                     shell=True)
         except OSError:


### PR DESCRIPTION
I tested type in some shells (bash, sh, zsh csh), particularly it doesn't work under zsh and csh, I think which is more reliable, works on the mentioned shells.
I omitted the "/bin/bash" as lukaslueg suggested and let python decide which shell to use.
Works fine now in freeBSD.
