### PR TITLE
Send signal SIGTERM instead of SIGKILL when timing out.

### DIFF
--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -348,7 +348,7 @@ class TorProcessProtocol(protocol.ProcessProtocol):
         """
 
         try:
-            self.transport.signalProcess('KILL')
+            self.transport.signalProcess('TERM')
         except error.ProcessExitedAlready:
             self.transport.loseConnection()
         self._did_timeout = True
@@ -377,7 +377,7 @@ class TorProcessProtocol(protocol.ProcessProtocol):
 
         self.cleanup()
 
-        if isinstance(status.value, error.ProcessDone):
+        if isinstance(status.value, error.ProcessDone) and not self._did_timeout:
             return
 
         if status.value.exitCode is None:


### PR DESCRIPTION
If the signal SIGKILL is send to Tor and you are using pluggable transports,
the pluggable transports will stay running and not be terminated.
