### PR TITLE
Check whether current hidden service dir is the same as other hidden service dir

### DIFF
--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -234,6 +234,7 @@ class EndpointTests(unittest.TestCase):
 
         def check(arg):
             self.assertEqual('127.0.0.1', ep.tcp_endpoint._interface)
+            self.assertEqual(len(self.config.HiddenServices), 1)
         d0.addCallback(check).addErrback(self.fail)
         return d0
 

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -400,11 +400,12 @@ class TCPHiddenServiceEndpoint(object):
                 info_callback.callback(None)
         self.config.protocol.add_event_listener('INFO', info_event)
 
-        self.hiddenservice = HiddenService(
-            self.config, self.hidden_service_dir,
-            ['%d 127.0.0.1:%d' % (self.public_port, self.local_port)],
-            group_readable=1)
-        self.config.HiddenServices.append(self.hiddenservice)
+        if not self.hidden_service_dir in map(lambda hs: hs.dir, self.config.HiddenServices):
+            self.hiddenservice = HiddenService(
+                self.config, self.hidden_service_dir,
+                ['%d 127.0.0.1:%d' % (self.public_port, self.local_port)],
+                group_readable=1)
+            self.config.HiddenServices.append(self.hiddenservice)
         yield self.config.save()
 
         self._tor_progress_update(100.0, 'wait_descriptor',


### PR DESCRIPTION
In case that the current hidden service dir is the same as the dir of any other hidden services, then change the current hidden service dir.