### PR TITLE
Fix/py3k

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 try:
     import pypissh
 except:
-    print "WARNING: not using PyPi over SSH!"
+    print("WARNING: not using PyPi over SSH!")
 import sys
 import os
 import shutil
@@ -36,7 +41,7 @@ setup(name = 'txtorcon',
       long_description = open('README.rst', 'r').read(),
       keywords = ['python', 'twisted', 'tor', 'tor controller'],
       ## way to have "development requirements"?
-      requires = filter(len, map(pip_to_requirements, open('requirements.txt').readlines())),
+      requires = list(filter(len, list(map(pip_to_requirements, open('requirements.txt').readlines())))),
       ## FIXME is requires even doing anything? why is format
       ## apparently different for install_requires?
       install_requires = ['Twisted>=11.1.0', 'zope.interface>=3.6.1'],
@@ -72,9 +77,9 @@ setup(name = 'txtorcon',
                     ## this includes the Sphinx source for the
                     ## docs. The "map+filter" construct grabs all .rst
                     ## files and re-maps the path
-                    ('share/txtorcon', ['docs/apilinks_sphinxext.py', 'docs/conf.py', 'docs/Makefile'] + map(lambda x: os.path.join('docs', x), filter(lambda x: x[-3:] == 'rst', os.listdir('docs'))) + map(lambda x: os.path.join('docs/_static', x), os.listdir('docs/_static'))),
+                    ('share/txtorcon', ['docs/apilinks_sphinxext.py', 'docs/conf.py', 'docs/Makefile'] + [os.path.join('docs', x) for x in [x for x in os.listdir('docs') if x[-3:] == 'rst']] + [os.path.join('docs/_static', x) for x in os.listdir('docs/_static')]),
 
                     ## include all the examples
-                    ('share/txtorcon/examples', map(lambda x: os.path.join('examples', x), filter(lambda x: x[-3:] == '.py', os.listdir('examples'))))
+                    ('share/txtorcon/examples', [os.path.join('examples', x) for x in [x for x in os.listdir('examples') if x[-3:] == '.py']])
                     ]
       )

--- a/txtorcon/__init__.py
+++ b/txtorcon/__init__.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 # for now, this needs to be changed in setup.py also until I find a
 # better solution
 __version__ = '0.13.0'
@@ -32,8 +39,8 @@ from txtorcon.endpoints import TCPHiddenServiceEndpointParser
 from txtorcon.endpoints import IHiddenService
 from txtorcon.endpoints import IProgressProvider
 from txtorcon.endpoints import get_global_tor
-import util
-import interface
+from . import util
+from . import interface
 from txtorcon.interface import *
 
 __all__ = ["Router",

--- a/txtorcon/addrmap.py
+++ b/txtorcon/addrmap.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 from txtorcon.interface import IAddrListener
 from txtorcon.util import maybe_ip_addr
 

--- a/txtorcon/circuit.py
+++ b/txtorcon/circuit.py
@@ -1,9 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 import time
 import datetime
 
 from twisted.python import log
 from twisted.internet import defer
-from interface import IRouterContainer
+from .interface import IRouterContainer
 
 from txtorcon.util import find_keywords
 
@@ -238,6 +245,6 @@ class Circuit(object):
                 oldpath = self.path
 
     def __str__(self):
-        path = ' '.join(map(lambda x: x.ip, self.path))
+        path = ' '.join([x.ip for x in self.path])
         return "<Circuit %d %s [%s] for %s>" % (self.id, self.state, path,
                                                 self.purpose)

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
 import os
 import shutil
 import weakref
@@ -20,8 +26,8 @@ from twisted.python.util import FancyEqMixin
 from zope.interface import implementer
 from zope.interface import Interface, Attribute
 
-from torconfig import TorConfig, launch_tor, HiddenService
-from torstate import build_tor_connection
+from .torconfig import TorConfig, launch_tor, HiddenService
+from .torstate import build_tor_connection
 
 
 _global_tor_config = None
@@ -400,7 +406,7 @@ class TCPHiddenServiceEndpoint(object):
                 info_callback.callback(None)
         self.config.protocol.add_event_listener('INFO', info_event)
 
-        if self.hidden_service_dir not in map(lambda hs: hs.dir, self.config.HiddenServices):
+        if self.hidden_service_dir not in [hs.dir for hs in self.config.HiddenServices]:
             self.hiddenservice = HiddenService(
                 self.config, self.hidden_service_dir,
                 ['%d 127.0.0.1:%d' % (self.public_port, self.local_port)],

--- a/txtorcon/interface.py
+++ b/txtorcon/interface.py
@@ -5,7 +5,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import with_statement
 
-from zope.interface import implements, Interface, Attribute
+from zope.interface import implementer
+from zope.interface import Interface, Attribute
 
 
 class IStreamListener(Interface):
@@ -59,14 +60,13 @@ class IStreamListener(Interface):
         """
 
 
+@implementer(IStreamListener)
 class StreamListenerMixin(object):
     """
     Implements all of :class:`txtorcon.IStreamListener` with no-op
     methods. You may subclass from this if you don't care about most
     of the notifications.
     """
-
-    implements(IStreamListener)
 
     def stream_new(self, stream):
         pass
@@ -227,12 +227,12 @@ class ICircuitListener(Interface):
         """
 
 
+@implementer(ICircuitListener)
 class CircuitListenerMixin(object):
     """
     Implements all of ICircuitListener with no-op methods. Subclass
     from this if you don't care about most of the notifications.
     """
-    implements(ICircuitListener)
 
     def circuit_new(self, circuit):
         pass

--- a/txtorcon/interface.py
+++ b/txtorcon/interface.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 from zope.interface import implements, Interface, Attribute
 
 

--- a/txtorcon/log.py
+++ b/txtorcon/log.py
@@ -1,6 +1,13 @@
+# -*- coding: utf-8 -*-
+
 """
 This module handles txtorcon debug messages.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
 
 from twisted.python import log as twlog
 

--- a/txtorcon/router.py
+++ b/txtorcon/router.py
@@ -1,6 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 from datetime import datetime
-from util import NetLocation
-import types
+from .util import NetLocation
+from .util import basestring
 
 
 def hexIdFromHash(thehash):
@@ -132,9 +139,9 @@ class Router(object):
         There is some current work in Twisted for open-ended constants
         (enums) support however, it seems.
         """
-        if isinstance(flags, types.StringType):
+        if isinstance(flags, basestring):
             flags = flags.split()
-        self._flags = map(lambda x: x.lower(), flags)
+        self._flags = [x.lower() for x in flags]
         self.name_is_unique = 'named' in self._flags
 
     @property

--- a/txtorcon/spaghetti.py
+++ b/txtorcon/spaghetti.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
 import warnings
 
 

--- a/txtorcon/stream.py
+++ b/txtorcon/stream.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Contains an implementation of a :class:`Stream abstraction used by
 :class:`TorState to represent all streams in Tor's state. There is
@@ -8,6 +10,11 @@ listening for stream updates (see also
 to attach streams to circuits "by hand"
 
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
 
 from twisted.python import log
 from twisted.internet import defer

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1,13 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import with_statement
 
 import os
 import sys
-import string
-import types
 import functools
 import tempfile
 import warnings
-from StringIO import StringIO
+from io import StringIO
 import shlex
 if sys.platform in ('linux2', 'darwin'):
     import pwd
@@ -468,7 +470,7 @@ def launch_tor(config, reactor,
         # FIXME? don't need rest of the args: uid, gid, usePTY, childFDs)
         transport.closeStdin()
 
-    except RuntimeError, e:
+    except RuntimeError as e:
         return defer.fail(e)
 
     if process_protocol.connected_cb:
@@ -557,7 +559,7 @@ class Time(TorConfigType):
 
 class CommaList(TorConfigType):
     def parse(self, s):
-        return map(string.strip, s.split(','))
+        return [x.strip() for x in s.split(',')]
 
 
 # FIXME: in latest master; what is it?
@@ -582,12 +584,12 @@ class Filename(String):
 
 class LineList(TorConfigType):
     def parse(self, s):
-        if isinstance(s, types.ListType):
-            return map(str, s)
-        return map(string.strip, s.split('\n'))
+        if isinstance(s, list):
+            return [str(x).strip() for x in s]
+        return [x.strip() for x in s.split('\n')]
 
     def validate(self, obj, instance, name):
-        if not isinstance(obj, types.ListType):
+        if not isinstance(obj, list):
             raise ValueError("Not valid for %s: %s" % (self.__class__, obj))
         return _ListWrapper(
             obj, functools.partial(instance.mark_unsaved, name))
@@ -704,7 +706,7 @@ class HiddenService(object):
         # in case people are passing '' for the auth
         if not auth:
             auth = []
-        elif not isinstance(auth, types.ListType):
+        elif not isinstance(auth, list):
             auth = [auth]
         self.authorize_client = _ListWrapper(
             auth, functools.partial(
@@ -719,7 +721,7 @@ class HiddenService(object):
         # OK' it seems from tor code that the keys will always have
         # been created on disk by that point
 
-        if not isinstance(ports, types.ListType):
+        if not isinstance(ports, list):
             ports = [ports]
         self.ports = _ListWrapper(ports, functools.partial(
             self.conf.mark_unsaved, 'HiddenServices'))
@@ -733,7 +735,7 @@ class HiddenService(object):
         watched_params = ['dir', 'version', 'authorize_client', 'ports']
         if name in watched_params and self.conf:
             self.conf.mark_unsaved('HiddenServices')
-        if isinstance(value, types.ListType):
+        if isinstance(value, list):
             value = _ListWrapper(value, functools.partial(
                 self.conf.mark_unsaved, 'HiddenServices'))
         self.__dict__[name] = value
@@ -1000,7 +1002,7 @@ class TorConfig(object):
             name = self._find_real_name(name)
             if not has_slutty_attr(self) and not is_hidden_services(name):
                 value = self.parsers[name].validate(value, self, name)
-            if isinstance(value, types.ListType):
+            if isinstance(value, list):
                 value = _ListWrapper(
                     value, functools.partial(self.mark_unsaved, name))
 
@@ -1146,7 +1148,7 @@ class TorConfig(object):
                             args.append(v)
                 continue
 
-            if isinstance(value, types.ListType):
+            if isinstance(value, list):
                 for x in value:
                     args.append(key)
                     args.append(str(x))
@@ -1177,7 +1179,7 @@ class TorConfig(object):
         return self
 
     def _find_real_name(self, name):
-        keys = self.__dict__['parsers'].keys() + self.__dict__['config'].keys()
+        keys = list(self.__dict__['parsers'].keys()) + list(self.__dict__['config'].keys())
         for x in keys:
             if x.lower() == name.lower():
                 return x
@@ -1308,7 +1310,7 @@ class TorConfig(object):
 
         '''
 
-        for (k, v) in self.config.items() + self.unsaved.items():
+        for (k, v) in list(self.config.items()) + list(self.unsaved.items()):
             if type(v) is _ListWrapper:
                 if k.lower() == 'hiddenservices':
                     for x in v:
@@ -1328,6 +1330,6 @@ class TorConfig(object):
         rtn = StringIO()
 
         for (k, v) in self.config_args():
-            rtn.write('%s %s\n' % (k, v))
+            rtn.write(u'%s %s\n' % (k, v))
 
         return rtn.getvalue()

--- a/txtorcon/torcontrolprotocol.py
+++ b/txtorcon/torcontrolprotocol.py
@@ -9,7 +9,8 @@ from twisted.internet import defer
 from twisted.internet.interfaces import IProtocolFactory
 from twisted.internet.error import ConnectionDone
 from twisted.protocols.basic import LineOnlyReceiver
-from zope.interface import implements
+
+from zope.interface import implementer
 
 from txtorcon.util import hmac_sha256, compare_via_hash
 from txtorcon.log import txtorlog
@@ -42,6 +43,7 @@ class TorProtocolError(RuntimeError):
         return str(self.code) + ' ' + self.text
 
 
+@implementer(IProtocolFactory)
 class TorProtocolFactory(object):
     """
     Builds TorControlProtocol objects. Implements IProtocolFactory for
@@ -50,8 +52,6 @@ class TorProtocolFactory(object):
     If your running Tor doesn't support COOKIE authentication, then
     you should supply a password callback.
     """
-
-    implements(IProtocolFactory)
 
     def __init__(self, password_function=lambda: None):
         """
@@ -176,6 +176,7 @@ def parse_keywords(lines, multiline_values=True):
     return rtn
 
 
+@implementer(ITorControlProtocol)
 class TorControlProtocol(LineOnlyReceiver):
     """
     This is the main class that talks to a Tor and implements the "raw"
@@ -194,8 +195,6 @@ class TorControlProtocol(LineOnlyReceiver):
     :class:`txtorcon.TorState`, which is also the place to go if you
     wish to add your own stream or circuit listeners.
     """
-
-    implements(ITorControlProtocol)
 
     def __init__(self, password_function=None):
         """

--- a/txtorcon/torcontrolprotocol.py
+++ b/txtorcon/torcontrolprotocol.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import with_statement
 
 from twisted.python import log
@@ -11,11 +15,10 @@ from txtorcon.util import hmac_sha256, compare_via_hash
 from txtorcon.log import txtorlog
 
 from txtorcon.interface import ITorControlProtocol
-from spaghetti import FSM, State, Transition
+from .spaghetti import FSM, State, Transition
 
 import os
 import re
-import types
 import base64
 
 DEFAULT_VALUE = 'DEFAULT'
@@ -142,7 +145,7 @@ def parse_keywords(lines, multiline_values=True):
         if '=' in line and ' ' not in line.split('=', 1)[0]:
             if key:
                 if key in rtn:
-                    if isinstance(rtn[key], types.ListType):
+                    if isinstance(rtn[key], list):
                         rtn[key].append(unquote(value))
                     else:
                         rtn[key] = [rtn[key], unquote(value)]
@@ -164,7 +167,7 @@ def parse_keywords(lines, multiline_values=True):
                 value = value + '\n' + line
     if key:
         if key in rtn:
-            if isinstance(rtn[key], types.ListType):
+            if isinstance(rtn[key], list):
                 rtn[key].append(unquote(value))
             else:
                 rtn[key] = [rtn[key], unquote(value)]
@@ -323,7 +326,7 @@ class TorControlProtocol(LineOnlyReceiver):
         GETINFO command. See :meth:`getinfo
         <txtorcon.TorControlProtocol.get_info>`
         """
-        info = ' '.join(map(lambda x: str(x), list(args)))
+        info = ' '.join([str(x) for x in list(args)])
         return self.queue_command('GETINFO %s' % info)
 
     def get_info_incremental(self, key, line_cb):
@@ -411,7 +414,7 @@ class TorControlProtocol(LineOnlyReceiver):
             d = defer.Deferred()
             d.errback(RuntimeError("Expected an even number of arguments."))
             return d
-        strargs = map(lambda x: str(x), args)
+        strargs = [str(x) for x in args]
         keys = [strargs[i] for i in range(0, len(strargs), 2)]
         values = [strargs[i] for i in range(1, len(strargs), 2)]
 
@@ -419,7 +422,7 @@ class TorControlProtocol(LineOnlyReceiver):
             if ' ' in s:
                 return '"%s"' % s
             return s
-        values = map(maybe_quote, values)
+        values = [maybe_quote(v) for v in values]
         args = ' '.join(map(lambda x, y: '%s=%s' % (x, y), keys, values))
         return self.queue_command('SETCONF ' + args)
 

--- a/txtorcon/torinfo.py
+++ b/txtorcon/torinfo.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import with_statement
+
 import functools
 from twisted.internet import defer
 
@@ -32,13 +39,13 @@ class MagicContainer(object):
         return object.__getattribute__(self, '_txtorcon_name')
 
     def __getitem__(self, idx):
-        return object.__getattribute__(self, 'attrs').items()[idx][1]
+        return list(object.__getattribute__(self, 'attrs').items())[idx][1]
 
     def __len__(self):
         return len(object.__getattribute__(self, 'attrs'))
 
     def __dir__(self):
-        return object.__getattribute__(self, 'attrs').keys()
+        return list(object.__getattribute__(self, 'attrs').keys())
 
     def __getattribute__(self, name):
         sup = super(MagicContainer, self)
@@ -47,7 +54,7 @@ class MagicContainer(object):
 
         attrs = sup.__getattribute__('attrs')
         if name == '__members__':
-            return attrs.keys()
+            return list(attrs.keys())
 
         else:
             if name.startswith('__'):
@@ -62,7 +69,7 @@ class MagicContainer(object):
 
     def dump(self, prefix):
         prefix = prefix + '.' + object.__getattribute__(self, '_txtorcon_name')
-        for x in object.__getattribute__(self, 'attrs').values():
+        for x in list(object.__getattribute__(self, 'attrs').values()):
             x.dump(prefix)
 
 
@@ -169,7 +176,7 @@ class TorInfo(object):
     def __getitem__(self, idx):
         sup = super(TorInfo, self)
         if sup.__getattribute__('_setup') is True:
-            return object.__getattribute__(self, 'attrs').items()[idx][1]
+            return list(object.__getattribute__(self, 'attrs').items())[idx][1]
         raise TypeError("No __getitem__ until we've setup.")
 
     def __len__(self):
@@ -183,8 +190,8 @@ class TorInfo(object):
     def __dir__(self):
         sup = super(TorInfo, self)
         if sup.__getattribute__('_setup') is True:
-            return sup.__getattribute__('attrs').keys()
-        return sup.__getattribute__('__dict__').keys()
+            return list(sup.__getattribute__('attrs').keys())
+        return list(sup.__getattribute__('__dict__').keys())
 
     def __getattribute__(self, name):
         sup = super(TorInfo, self)
@@ -193,7 +200,7 @@ class TorInfo(object):
 
         attrs = sup.__getattribute__('attrs')
         if name == '__members__':
-            return attrs.keys()
+            return list(attrs.keys())
 
         else:
             try:

--- a/txtorcon/torstate.py
+++ b/txtorcon/torstate.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
+import collections
 import datetime
 import os
 import stat
@@ -27,7 +34,8 @@ from txtorcon.interface import ICircuitListener
 from txtorcon.interface import ICircuitContainer
 from txtorcon.interface import IStreamListener
 from txtorcon.interface import IStreamAttacher
-from spaghetti import FSM, State, Transition
+from .spaghetti import FSM, State, Transition
+from .util import basestring
 
 
 def _build_state(proto):
@@ -105,10 +113,13 @@ def build_tor_connection(connection, build_state=True, wait_for_proto=True,
         )
     )
     if build_state:
-        d.addCallback(build_state if callable(build_state) else _build_state)
+        d.addCallback(build_state
+                      if isinstance(build_state, collections.Callable)
+                      else _build_state)
     elif wait_for_proto:
-        d.addCallback(wait_for_proto if callable(wait_for_proto) else
-                      _wait_for_proto)
+        d.addCallback(wait_for_proto
+                      if isinstance(wait_for_proto, collections.Callable)
+                      else _wait_for_proto)
     return d
 
 
@@ -147,7 +158,7 @@ def flags_from_dict(kw):
         return ''
 
     flags = ''
-    for (k, v) in kw.iteritems():
+    for (k, v) in kw.items():
         if v:
             flags += ' ' + str(k)
     # note that we want the leading space if there's at least one
@@ -571,7 +582,7 @@ class TorState(object):
                     first = False
                 else:
                     cmd += ','
-                if isinstance(router, types.StringType) and len(router) == 40 \
+                if isinstance(router, basestring) and len(router) == 40 \
                    and hashFromHexId(router):
                     cmd += router
                 else:

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import with_statement
+
 import glob
 import os
 import hmac
@@ -23,6 +29,15 @@ city = None
 country = None
 asn = None
 
+try:
+    unicode
+except NameError:
+    py3k = True
+    basestring = str
+else:
+    py3k = False
+    basestring = basestring
+
 
 def create_geoip(fname):
     # It's more "pythonic" to just wait for the exception,
@@ -44,10 +59,10 @@ def maybe_create_db(path):
     except IOError:
         return None
 
-city, asn, country = map(maybe_create_db,
+city, asn, country = list(map(maybe_create_db,
                          ("/usr/share/GeoIP/GeoLiteCity.dat",
                           "/usr/share/GeoIP/GeoIPASNum.dat",
-                          "/usr/share/GeoIP/GeoIP.dat"))
+                          "/usr/share/GeoIP/GeoIP.dat")))
 
 try:
     import ipaddr as _ipaddr
@@ -132,7 +147,7 @@ def find_keywords(args, key_filter=lambda x: not x.startswith("$")):
         a dict of key->value (both strings) of all name=value type
         keywords found in args.
     """
-    filtered = filter(lambda x: '=' in x and key_filter(x.split('=')[0]), args)
+    filtered = [x for x in args if '=' in x and key_filter(x.split('=')[0])]
     return dict(x.split('=', 1) for x in filtered)
 
 

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -15,7 +15,13 @@ import struct
 
 from twisted.internet import defer
 from twisted.internet.interfaces import IProtocolFactory
-from twisted.internet.endpoints import serverFromString
+
+# FIXME: Remove this try/except block when t.i.e.serverFromString is available
+# in py3k.  See also the related hack in :func:`available_tcp_port`.
+try:
+    from twisted.internet.endpoints import serverFromString
+except ImportError:
+    serverFromString = None
 
 from zope.interface import implementer
 
@@ -283,7 +289,13 @@ def available_tcp_port(reactor):
     assigned port number.
     """
 
-    endpoint = serverFromString(reactor, 'tcp:0:interface=127.0.0.1')
+    # FIXME: Remove this if/else block when t.i.e.serverFromString is
+    # available in py3k.
+    if serverFromString:
+        endpoint = serverFromString(reactor, 'tcp:0:interface=127.0.0.1')
+    else:
+        endpoint = TCP4ServerEndpoint(reactor, 0, backlog=50, interface='127.0.0.1')
+
     port = yield endpoint.listen(NoOpProtocolFactory())
     address = port.getHost()
     yield port.stopListening()


### PR DESCRIPTION
My `fix/py3k` branch contains some initial changes for maintaining simultaneous Python 2 and Python 3 compatibility.

Running `make test` passes for both python2.7 and python3.4.

However, Python3.4 with Twisted==15.2.0 is still not working, mostly due to txtorcon's pervasive use of the Twisted Endpoints API, not all of which has been ported to py3k yet (specifically, `t.i.e.UNIXServerEndpoint` and `t.i.e.UNIXClientEndpoint`, which currently seems to be the largest barrier to running txtorcon with Python 3).

The use of:

```
from __future__ import unicode_literals
```

was messing up the use of `twisted.internet.protocols` and also [appeared to break setuptools in many ways](https://mail.python.org/pipermail/distutils-sig/2013-July/021442.html), so I removed the line (which I had originally added to all txtorcon's files) from some of the files. The rest might need to be removed? The tests pass, at least…

------
One other thing to note is that the version of ipaddr that txtorcon pins uses a deprecated syntax for designating `long`s, i.e.: `0L`. To work around this, I had to basically do:

```
curl -o ipaddr-2.1.11.tar.gz https://pypi.python.org/packages/source/i/ipaddr/ipaddr-2.1.11.tar.gz#md5=f2c7852f95862715f92e7d089dc3f2cf
md5sum ipaddr-2.1.11.tar.gz
tar xvf ipaddr-2.1.11.tar.gz && cd ipaddr-2.1.11
```
and replace the `0L` with `0`. (I think this was all I had to do.)

