### PR TITLE
Use stem class for parsing relay descriptor

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -172,6 +172,22 @@ for logging things INFO, NOTICE, WARN, ERR.
 
 
 
+.. _stem_relay_descriptor.py:
+
+:file:`stem_relay_descriptor.py`
+--------------------------------
+
+:download: `Download the example <../examples/stem_relay_descriptor>`.
+
+Get information about a relay descriptor with the help of `Stem's
+Relay Descriptor class <https://stem.torproject.org/api/descriptor/server_descriptor.html#stem.descriptor.server_descriptor.RelayDescriptor>`. We need to specify the nickname or the fingerprint to get back
+the details.
+
+.. literalinclude:: ../examples/stem_relay_descriptor.py
+
+
+
+
 .. _circuit_failure_rates.py:
 
 :file:`circuit_failure_rates.py`

--- a/examples/stem_relay_descriptor.py
+++ b/examples/stem_relay_descriptor.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# This shows how to get the detailed information about a
+# relay descriptor and parse it into Stem's Relay Descriptor
+# class. More about the class can be read from
+#
+# https://stem.torproject.org/api/descriptor/server_descriptor.html#stem.descriptor.server_descriptor.RelayDescriptor
+#
+# We need to pass the nickname or the fingerprint of the onion
+# router for which we need the the descriptor information,
+
+from twisted.internet.task import react
+from twisted.internet.defer import inlineCallbacks
+import txtorcon
+
+
+@inlineCallbacks
+def main(reactor):
+    proto = yield txtorcon.build_local_tor_connection(reactor, build_state=False)
+
+    or_nickname = "moria1"
+    print "Trying to get decriptor information about", or_nickname
+    # If the fingerprint is used in place of nickname then, desc/id/<OR identity>
+    # should be used.
+    descriptor_info = yield proto.get_info('desc/name/' + or_nickname)
+
+    descriptor_info = descriptor_info['desc/name/' + or_nickname]
+    try:
+        from stem.descriptor.server_descriptor import RelayDescriptor
+        relay_info = RelayDescriptor(descriptor_info) 
+        print "The relay's fingerprint is:", relay_info.fingerprint
+        print "Time in UTC when the descriptor was made:", relay_info.published
+    except ImportError as e:
+        print "Error:", e
+
+
+if __name__ == '__main__':
+    react(main)


### PR DESCRIPTION
Use stem Relay Descriptor class to parse the descriptor information. More about the stem class can be read at https://stem.torproject.org/api/descriptor/server_descriptor.html#stem.descriptor.server_descriptor.RelayDescriptor