### PR TITLE
Parse desc/name and desc/id responses into Stem's RelayDescriptor class

### DIFF
--- a/txtorcon/torinfo.py
+++ b/txtorcon/torinfo.py
@@ -99,6 +99,13 @@ class ConfigMethod(object):
 
         d = self.proto.get_info_raw(req)
         d.addCallback(functools.partial(stripper, req))
+        descriptor_keys = ["desc/name", "desc/id"]
+        if self.info_key in descriptor_keys and self.proto.use_stem:
+            # Parse the descriptor information into Stem's RelayDescriptor class
+            # More about the class can be read at,
+            # https://stem.torproject.org/api/descriptor/server_descriptor.html#stem.descriptor.server_descriptor.RelayDescriptor
+            from stem.descriptor.server_descriptor import RelayDescriptor
+            d.addCallback(RelayDescriptor)
         return d
 
     def __str__(self):


### PR DESCRIPTION
Implemented _get_descriptor() method
The parameters for the method are, `nickname`, `fingerprint`. These are the relay's nickname/fingerprint for which we want the descriptor information.
Returns the descriptor information. If use_stem is set to True, a `stem.descriptor.server_descriptor.RelayDescriptor` object is returned with the descriptor information.