### PR TITLE
Endpoint tests and refactor

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,9 @@ unreleased
    commands in TorConfig
  * a first stealth-authentication implementation (for "normal" hidden
    services, not ephemeral)
+ * bug-fix from `david415 <https://github.com/david415>`_ to raise
+   ConnectionRefusedError instead of StopIteration when running out of
+   SOCKS ports.
 
 
 v0.14.0

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -587,10 +587,10 @@ class TestTorClientEndpoint(unittest.TestCase):
         This test is equivalent to txsocksx's
         TestSOCKS4ClientEndpoint.test_clientConnectionFailed
         """
-        def FailTorSocksEndpointGenerator(*args, **kw):
+        def fail_tor_socks_endpoint_generator(*args, **kw):
             kw['failure'] = Failure(ConnectionRefusedError())
             return FakeTorSocksEndpoint(*args, **kw)
-        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=FailTorSocksEndpointGenerator)
+        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=fail_tor_socks_endpoint_generator)
         d = endpoint.connect(None)
         return self.assertFailure(d, ConnectionRefusedError)
 
@@ -598,13 +598,13 @@ class TestTorClientEndpoint(unittest.TestCase):
         """
         Same as above, but with a username/password.
         """
-        def FailTorSocksEndpointGenerator(*args, **kw):
+        def fail_tor_socks_endpoint_generator(*args, **kw):
             kw['failure'] = Failure(ConnectionRefusedError())
             return FakeTorSocksEndpoint(*args, **kw)
         endpoint = TorClientEndpoint(
             'invalid host', 0,
             socks_username='billy', socks_password='s333cure',
-            _proxy_endpoint_generator=FailTorSocksEndpointGenerator)
+            _proxy_endpoint_generator=fail_tor_socks_endpoint_generator)
         d = endpoint.connect(None)
         return self.assertFailure(d, ConnectionRefusedError)
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -651,10 +651,10 @@ class TestTorClientEndpoint(unittest.TestCase):
         """
         This test is equivalent to txsocksx's TestSOCKS5ClientEndpoint.test_defaultFactory
         """
-        def TorSocksEndpointGenerator(*args, **kw):
+        def tor_socks_endpoint_generator(*args, **kw):
             return FakeTorSocksEndpoint(*args, **kw)
-        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=TorSocksEndpointGenerator)
-        endpoint.connect(None)
+        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=tor_socks_endpoint_generator)
+        endpoint.connect(Mock)
         self.assertEqual(endpoint.tor_socks_endpoint.transport.value(), '\x05\x01\x00')
 
     def test_good_port_retry(self):

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -615,6 +615,18 @@ class TestTorClientEndpoint(unittest.TestCase):
         # just ensuring the default generator doesn't blow up
         default_tcp4_endpoint_generator(None, 'foo.bar', 1234)
 
+    @defer.inlineCallbacks
+    def test_stop_iteration_becomes_refused(self):
+        fake_endpoint = Mock()
+        proto_factory = Mock()
+
+        TorClientEndpoint.socks_ports_to_try = []
+        ep = TorClientEndpoint('a host', 0)
+        try:
+            yield ep.connect(proto_factory)
+        except Exception as e:
+            self.assertTrue(isinstance(e, ConnectionRefusedError))
+
     def test_no_host(self):
         self.assertRaises(
             ValueError,

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -612,18 +612,6 @@ class TestTorClientEndpoint(unittest.TestCase):
         # just ensuring the default generator doesn't blow up
         default_tcp4_endpoint_generator(None, 'foo.bar', 1234)
 
-    @defer.inlineCallbacks
-    def test_stop_iteration_becomes_refused(self):
-        fake_endpoint = Mock()
-        proto_factory = Mock()
-
-        with patch.object(TorClientEndpoint, 'socks_ports_to_try', []):
-            ep = TorClientEndpoint('a host', 0)
-            try:
-                yield ep.connect(proto_factory)
-            except Exception as e:
-                self.assertIsInstance(e, ConnectionRefusedError)
-
     def test_no_host(self):
         self.assertRaises(
             ValueError,

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -612,7 +612,7 @@ class TestTorClientEndpoint(unittest.TestCase):
         return self.assertFailure(d, ConnectionRefusedError)
 
     def test_default_generator(self):
-        # just ensuring the default generator doesn't blow updoesn't blow up
+        # just ensuring the default generator doesn't blow up
         default_tcp4_endpoint_generator(None, 'foo.bar', 1234)
 
     def test_no_host(self):

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -663,7 +663,7 @@ class TorClientEndpoint(object):
         self.port = int(port)
         self._proxy_endpoint_generator = _proxy_endpoint_generator
         self.socks_hostname = socks_hostname
-        self.socks_port = int(socks_port) if socks_port else None
+        self.socks_port = int(socks_port) if socks_port is not None else None
         self.socks_username = socks_username
         self.socks_password = socks_password
 

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -23,10 +23,11 @@ from twisted.internet.interfaces import IAddress
 from twisted.internet.endpoints import serverFromString
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.error import ConnectionRefusedError
 from twisted.internet import error
 from twisted.plugin import IPlugin
 from twisted.python.util import FancyEqMixin
-from twisted.internet.error import ConnectionRefusedError
+from twisted.python.failure import Failure
 
 from zope.interface import implementer
 from zope.interface import Interface, Attribute

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -686,19 +686,18 @@ class TorClientEndpoint(object):
                 self.socks_hostname,
                 self.socks_port,
             )
-            if self.socks_username is None or self.socks_password is None:
-                ep = SOCKS5ClientEndpoint(
-                    self.host,
-                    self.port,
-                    self.tor_socks_endpoint
+            kw = dict()
+            if self.socks_username is not None and self.socks_password is not None:
+                kw['methods'] = dict(
+                    login=(self.socks_username, self.socks_password),
                 )
-            else:
-                ep = SOCKS5ClientEndpoint(
-                    self.host,
-                    self.port,
-                    self.tor_socks_endpoint,
-                    methods=dict(login=(self.socks_username, self.socks_password))
-                )
+
+            ep = SOCKS5ClientEndpoint(
+                self.host,
+                self.port,
+                self.tor_socks_endpoint,
+                **kw
+            )
 
             try:
                 proto = yield ep.connect(protocolfactory)


### PR DESCRIPTION
This started out as making a test for the "success" path, but I ended up re-factoring the TorClientEndpoint to eliminate some state and use @inlineCallbacks instead of several _private_methods

Also some CamelCase to snake_case for function names etc.

@david415 what do you think?