### PR TITLE
Fix EphemeralHiddenService key blob size constraint

### DIFF
--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -846,7 +846,7 @@ class EphemeralHiddenService(object):
         # FIXME nicer than assert, plz
         assert ' ' not in self._key_blob
         assert type(ports) is types.ListType
-        if not key_blob_or_type.startswith('NEW:') and len(key_blob_or_type) > (825):
+        if not key_blob_or_type.startswith('NEW:') and (len(key_blob_or_type) > (825) or len(key_blob_or_type) < (820)):
             raise RuntimeError('Wrong key-blob size too big')
 
     @defer.inlineCallbacks

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -846,8 +846,8 @@ class EphemeralHiddenService(object):
         # FIXME nicer than assert, plz
         assert ' ' not in self._key_blob
         assert type(ports) is types.ListType
-        if not key_blob_or_type.startswith('NEW:') and len(key_blob_or_type) != (812 + 8):
-            raise RuntimeError('Wrong size key-blob')
+        if not key_blob_or_type.startswith('NEW:') and len(key_blob_or_type) > (825):
+            raise RuntimeError('Wrong key-blob size too big')
 
     @defer.inlineCallbacks
     def add_to_tor(self, protocol):


### PR DESCRIPTION
key blobs can be between 820 and 825 bytes