### PR TITLE
Fix config value parsing issues 

### DIFF
--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -237,6 +237,10 @@ class ConfigTests(unittest.TestCase):
                                               ('foo', 1),
                                               ('bar', 0),
                                               ('qux', 'auto')])
+        self.assertTrue(conf.foo is 1)
+        self.assertTrue(conf.bar is 0)
+        self.assertTrue(conf.baz is 1)
+        self.assertTrue(conf.qux is -1)
 
     def test_save_invalid_boolean_auto(self):
         self.protocol.answers.append(

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -300,9 +300,12 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(conf.foo, 0)
 
         for value in ('no', 'Not a value', None):
-            with self.assertRaises((ValueError, TypeError)):
+            try:
                 conf.foo = value
-
+            except (ValueError, TypeError):
+                pass
+            else:
+                self.fail("No excpetion thrown")
 
     def test_int_parser_error(self):
         self.protocol.answers.append('config/names=\nfoo Integer')
@@ -744,8 +747,12 @@ class EventTests(unittest.TestCase):
 
         config = TorConfig(protocol)
         # Initial value is not tested here
-        with self.assertRaises((ValueError, TypeError)):
+        try:
             protocol.events['CONF_CHANGED']('Foo=INVALID\nBar=VALUES')
+        except (ValueError, TypeError):
+            pass
+        else:
+            self.fail("No excpetion thrown")
 
 class CreateTorrcTests(unittest.TestCase):
 

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -713,6 +713,36 @@ class EventTests(unittest.TestCase):
         self.assertEqual(config.Foo, 'bar')
         self.assertEqual(config.Bar, DEFAULT_VALUE)
 
+    def test_conf_changed_parsed(self):
+        '''
+        Create a configuration which holds boolean types. These types
+        have to be parsed as booleans.
+        '''
+        protocol = FakeControlProtocol([])
+        protocol.answers.append('config/names=\nFoo Boolean\nBar Boolean')
+        protocol.answers.append({'Foo': '0'})
+        protocol.answers.append({'Bar': '1'})
+
+        config = TorConfig(protocol)
+        # Initial value is not tested here
+        protocol.events['CONF_CHANGED']('Foo=1\nBar=0')
+
+        msg = "Foo is not True: %r" % config.Foo
+        self.assertTrue(config.Foo is True, msg=msg)
+
+        msg = "Foo is not False: %r" % config.Bar
+        self.assertTrue(config.Bar is False, msg=msg)
+
+    def test_conf_changed_invalid_values(self):
+        protocol = FakeControlProtocol([])
+        protocol.answers.append('config/names=\nFoo Integer\nBar Integer')
+        protocol.answers.append({'Foo': '0'})
+        protocol.answers.append({'Bar': '1'})
+
+        config = TorConfig(protocol)
+        # Initial value is not tested here
+        with self.assertRaises((ValueError, TypeError)):
+            protocol.events['CONF_CHANGED']('Foo=INVALID\nBar=VALUES')
 
 class CreateTorrcTests(unittest.TestCase):
 

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -177,7 +177,8 @@ class ConfigTests(unittest.TestCase):
         conf.foo = True
         conf.bar = False
         conf.save()
-        self.assertEqual(self.protocol.sets, [('foo', 1), ('bar', 0)])
+        self.assertEqual(set(self.protocol.sets),
+                         set([('foo', 1), ('bar', 0)]))
 
     def test_read_boolean_after_save(self):
         self.protocol.answers.append('config/names=\nfoo Boolean\nbar Boolean')
@@ -203,7 +204,8 @@ class ConfigTests(unittest.TestCase):
         conf.foo = "Something True"
         conf.bar = 0
         conf.save()
-        self.assertEqual(self.protocol.sets, [('foo', 1), ('bar', 0)])
+        self.assertEqual(set(self.protocol.sets),
+                         set([('foo', 1), ('bar', 0)]))
 
     def test_boolean_auto_parser(self):
         self.protocol.answers.append(
@@ -233,10 +235,11 @@ class ConfigTests(unittest.TestCase):
         conf.baz = True
         conf.qux = -1
         conf.save()
-        self.assertEqual(self.protocol.sets, [('baz', 1),
-                                              ('foo', 1),
-                                              ('bar', 0),
-                                              ('qux', 'auto')])
+        self.assertEqual(set(self.protocol.sets),
+                         set([('foo', 1),
+                              ('bar', 0),
+                              ('baz', 1),
+                              ('qux', 'auto')]))
         self.assertTrue(conf.foo is 1)
         self.assertTrue(conf.bar is 0)
         self.assertTrue(conf.baz is 1)

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1268,7 +1268,10 @@ class TorConfig(object):
         for (k, v) in conf.items():
             # v will be txtorcon.DEFAULT_VALUE already from
             # parse_keywords if it was unspecified
-            self.config[self._find_real_name(k)] = v
+            real_name = self._find_real_name(k)
+            if real_name in self.parsers:
+                v = self.parsers[real_name].parse(v)
+            self.config[real_name] = v
 
     def bootstrap(self, arg=None):
         '''

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -500,10 +500,16 @@ class TorConfigType(object):
 
 
 class Boolean(TorConfigType):
+    "Boolean values are stored as 0 or 1."
     def parse(self, s):
         if int(s):
             return True
         return False
+
+    def validate(self, s, instance, name):
+        if s:
+            return 1
+        return 0
 
 
 class Boolean_Auto(TorConfigType):
@@ -519,6 +525,16 @@ class Boolean_Auto(TorConfigType):
         if int(s):
             return 1
         return 0
+
+    def validate(self, s, instance, name):
+        # FIXME: Is 'auto' an allowed value? (currently not)
+        s = int(s)
+        if s < 0:
+            return 'auto'
+        elif s:
+            return 1
+        else:
+            return 0
 
 
 class Integer(TorConfigType):
@@ -805,8 +821,8 @@ class HiddenService(object):
         if self.conf._supports['HiddenServiceDirGroupReadable'] \
            and self.group_readable:
             rtn.append(('HiddenServiceDirGroupReadable', str(1)))
-        for x in self.ports:
-            rtn.append(('HiddenServicePort', str(x)))
+        for port in self.ports:
+            rtn.append(('HiddenServicePort', str(port)))
         if self.version:
             rtn.append(('HiddenServiceVersion', str(self.version)))
         for authline in self.authorize_client:

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -541,6 +541,9 @@ class Integer(TorConfigType):
     def parse(self, s):
         return int(s)
 
+    def validate(self, s, instance, name):
+        return int(s)
+
 
 class SignedInteger(Integer):
     pass
@@ -1345,7 +1348,10 @@ class TorConfig(object):
 
             # FIXME in future we should wait for CONF_CHANGED and
             # update then, right?
-            self.config[self._find_real_name(key)] = value
+            real_name = self._find_real_name(key)
+            if not isinstance(value, list) and real_name in self.parsers:
+                value = self.parsers[real_name].parse(value)
+            self.config[real_name] = value
 
         # FIXME might want to re-think this, but currently there's no
         # way to put things into a config and get them out again


### PR DESCRIPTION
Hi
I noticed some bugs in the `TorConfig`:
  * When saving boolean values the save call fails: 
```python
>>> config.AllowSingleHopCircuits = True
>>> config.save() # Fails because tor expects 0 or 1 not "True"
```
 * When saving boolean values the saved value is not converted to boolean:
```python
>>> config = TorConfig(protocol)
>>> config.AllowSingleHopCircuits = 1
>>> config.save()
>>> config.AllowSingleHopCircuits
1
>>> config = TorConfig(protocol)
>>> config.AllowSingleHopCircuits
True
```
* When a `CONF_CHANGED` is received the value isn't parsed at all (tried after eea94c89407029ce0f1463e65c87a350ab8b9acc):
```python
>>> config.AllowSingleHopCircuits = True
>>> config.save()
>>> config.AllowSingleHopCircuits
True
>>> # some time passes
...
>>> config.AllowSingleHopCircuits
'1'
```

I've made some changed and it seems to work for me but I don't know if you like the implementation.

Regards