### PR TITLE
Correct string unescaping

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -292,6 +292,9 @@ class TestFilenameEscaping(unittest.TestCase):
             ("\\'", "'"),           # \'     -> '
             ("\\\\\\'", "\\'"),     # \\\'   -> \'
             (r'some\"text', 'some"text'),
+            ('some\\word', 'someword'),
+            ('\\delete\\ al\\l un\\used \\backslashes',
+             'delete all unused backslashes'),
             ('\\n\\r\\t', '\n\r\t'),
             ('\\x00 \\x0123', 'x00 x0123'),
             ('\\\\x00 \\\\x00', '\\x00 \\x00'),
@@ -330,7 +333,6 @@ class TestFilenameEscaping(unittest.TestCase):
             '"\\"',     # \     - unescaped backslash
             '"\\\\\\"', # \\\   - uneven backslashes
             '"\\\\""',  # \\"   - quotes not escaped
-            '"\'"'      # '     - unescaped single quote
         ]
 
         for invalid_string in invalid_escaped:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -280,28 +280,29 @@ class TestIpAddr(unittest.TestCase):
         ip = maybe_ip_addr('1.2.3.4')
 
 
-class TestFilenameEscaping(unittest.TestCase):
-
+class TestUnescapeQuotedString(unittest.TestCase):
+    '''
+    Test cases for the function unescape_quoted_string.
+    '''
     def test_valid_string_unescaping(self):
-        unescapeable = [
-            ('\\\\', '\\'),         # \\     -> \
-            (r'\"', r'"'),          # \"     -> "
-            (r'\\\"', r'\"'),       # \\\"   -> \"
-            (r'\\\\\"', r'\\"'),    # \\\\\" -> \\"
-            ('\\"\\\\', '"\\'),     # \"\\   -> "\
-            ("\\'", "'"),           # \'     -> '
-            ("\\\\\\'", "\\'"),     # \\\'   -> \'
-            (r'some\"text', 'some"text'),
-            ('some\\word', 'someword'),
-            ('\\delete\\ al\\l un\\used \\backslashes',
-             'delete all unused backslashes'),
-            ('\\n\\r\\t', '\n\r\t'),
-            ('\\x00 \\x0123', 'x00 x0123'),
-            ('\\\\x00 \\\\x00', '\\x00 \\x00'),
-            ('\\\\\\x00  \\\\\\x00', '\\x00  \\x00')
-        ]
+        unescapeable = {
+            '\\\\': '\\',         # \\     -> \
+            r'\"': r'"',          # \"     -> "
+            r'\\\"': r'\"',       # \\\"   -> \"
+            r'\\\\\"': r'\\"',    # \\\\\" -> \\"
+            '\\"\\\\': '"\\',     # \"\\   -> "\
+            "\\'": "'",           # \'     -> '
+            "\\\\\\'": "\\'",     # \\\'   -> \
+            r'some\"text': 'some"text',
+            'some\\word': 'someword',
+            '\\delete\\ al\\l un\\used \\backslashes': 'delete all unused backslashes',
+            '\\n\\r\\t': '\n\r\t',
+            '\\x00 \\x0123': 'x00 x0123',
+            '\\\\x00 \\\\x00': '\\x00 \\x00',
+            '\\\\\\x00  \\\\\\x00': '\\x00  \\x00'
+        }
 
-        for escaped, correct_unescaped in unescapeable:
+        for escaped, correct_unescaped in unescapeable.items():
             escaped = '"{}"'.format(escaped)
             unescaped = unescape_quoted_string(escaped)
             msg = "Wrong unescape: {escaped} -> {unescaped} instead of {correct}"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -11,6 +11,7 @@ from txtorcon.util import find_keywords
 from txtorcon.util import ip_from_int
 from txtorcon.util import find_tor_binary
 from txtorcon.util import maybe_ip_addr
+from txtorcon.util import unescape_path
 
 import os
 import tempfile
@@ -277,3 +278,22 @@ class TestIpAddr(unittest.TestCase):
             raise ValueError('testing')
         ipaddr.IPAddress.side_effect = foo
         ip = maybe_ip_addr('1.2.3.4')
+
+
+class TestFilenameEscaping(unittest.TestCase):
+
+    def test_valid_path_unescaping(self):
+        unescapeable = [
+            ('\\\\', '\\'),         # \\     -> \
+            (r'\"', r'"'),          # \"     -> "
+            (r'\\\"', r'\"'),       # \\\"   -> \"
+            (r'\\\\\"', r'\\"'),    # \\\\\" -> \\"
+            ('\\"\\\\', '"\\')      # \"\\   -> "\
+        ]
+
+        for escaped, correct_unescaped in unescapeable:
+            unescaped = unescape_path(escaped)
+            msg = "Wrong unescape: {escaped} -> {unescaped} instead of {correct}"
+            msg = msg.format(unescaped=unescaped, escaped=escaped,
+                             correct=correct_unescaped)
+            self.assertEqual(unescaped, correct_unescaped, msg=msg)

--- a/txtorcon/torcontrolprotocol.py
+++ b/txtorcon/torcontrolprotocol.py
@@ -12,7 +12,7 @@ from twisted.protocols.basic import LineOnlyReceiver
 
 from zope.interface import implementer
 
-from txtorcon.util import hmac_sha256, compare_via_hash
+from txtorcon.util import hmac_sha256, compare_via_hash, unescape_path
 from txtorcon.log import txtorlog
 
 from txtorcon.interface import ITorControlProtocol
@@ -679,8 +679,7 @@ class TorControlProtocol(LineOnlyReceiver):
             cookiefile_match = re.search(r'COOKIEFILE="((?:[^"\\]|\\.)*)"', protoinfo)
             if cookiefile_match:
                 cookiefile = cookiefile_match.group(1)
-                cookiefile = cookiefile.replace('\\\\', '\\')
-                cookiefile = cookiefile.replace('\\"', '"')
+                cookiefile = unescape_path(cookiefile)
                 try:
                     self._read_cookie(cookiefile)
                 except IOError as why:

--- a/txtorcon/torcontrolprotocol.py
+++ b/txtorcon/torcontrolprotocol.py
@@ -12,7 +12,7 @@ from twisted.protocols.basic import LineOnlyReceiver
 
 from zope.interface import implementer
 
-from txtorcon.util import hmac_sha256, compare_via_hash, unescape_path
+from txtorcon.util import hmac_sha256, compare_via_hash, unescape_quoted_string
 from txtorcon.log import txtorlog
 
 from txtorcon.interface import ITorControlProtocol
@@ -663,7 +663,6 @@ class TorControlProtocol(LineOnlyReceiver):
         Callback on PROTOCOLINFO to actually authenticate once we know
         what's supported.
         """
-
         methods = None
         cookie_auth = False
         for line in protoinfo.split('\n'):
@@ -676,10 +675,11 @@ class TorControlProtocol(LineOnlyReceiver):
             )
 
         if 'SAFECOOKIE' in methods or 'COOKIE' in methods:
-            cookiefile_match = re.search(r'COOKIEFILE="((?:[^"\\]|\\.)*)"', protoinfo)
+            cookiefile_match = re.search(r'COOKIEFILE=("(?:[^"\\]|\\.)*")',
+                                         protoinfo)
             if cookiefile_match:
                 cookiefile = cookiefile_match.group(1)
-                cookiefile = unescape_path(cookiefile)
+                cookiefile = unescape_quoted_string(cookiefile)
                 try:
                     self._read_cookie(cookiefile)
                 except IOError as why:

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -292,3 +292,9 @@ def available_tcp_port(reactor):
     address = port.getHost()
     yield port.stopListening()
     defer.returnValue(address.port)
+
+
+def unescape_path(path):
+    path = path.replace('\\\\', '\\')
+    path = path.replace('\\"', '"')
+    return path

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -297,25 +297,23 @@ def available_tcp_port(reactor):
 
 def unescape_quoted_string(string):
     r'''
-    Unescape a double quoted string.
-    An escaped string may contain only escaped backslashes `\\` or backslashes
-    in front of double quotes to escape the quote: `\"`.
+    This function implementes the recommended functionality described in the
+    tor control-spec to be compatible with older tor versions:
 
-    From the Tor control specifications::
+      * Read \\n \\t \\r and \\0 ... \\377 as C escapes.
+      * Treat a backslash followed by any other character as that character.
 
-      For future-proofing, controller implementors MAY use the following
-      rules to be compatible with buggy Tor implementations and with
-      future ones that implement the spec as intended:
+    Except the legacy support for the escape sequences above this function
+    implements parsing of QuotedString using qcontent from
 
-        Read \n \t \r and \0 ... \377 as C escapes.
-        Treat a backslash followed by any other character as that character.
+    QuotedString = DQUOTE *qcontent DQUOTE
 
-    :param string: The escaped string.
+    :param string: The escaped quoted string.
     :returns: The unescaped string.
     :raises ValueError: If the string is in a invalid form
                         (e.g. a single backslash)
     '''
-    match = re.match(r'''^"((?:[^"'\\]|\\.)*)"$''', string)
+    match = re.match(r'''^"((?:[^"\\]|\\.)*)"$''', string)
     if not match:
         raise ValueError("Invalid quoted string", string)
     string = match.group(1)


### PR DESCRIPTION
It would good to implement a function to unescapes strings according to the descriptions in the
[control spec (2.2.1)](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt#n110).

I tried to do this and define some tests.