### PR TITLE
Modify a few tests to use `pytest`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,4 @@ pep8
 mock
 ipaddress>=1.0.16
 GeoIP
+pytest

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -4,6 +4,8 @@ from twisted.internet import defer
 
 from txtorcon.router import Router, hexIdFromHash, hashFromHexId
 
+import pytest
+
 
 class FakeController(object):
     def get_info_raw(self, i):
@@ -26,6 +28,19 @@ class UtilityTests(unittest.TestCase):
             hexIdFromHash(hashFromHexId('00786E43CCC5409753F25E36031C5CEA6EA43702')),
             '$00786E43CCC5409753F25E36031C5CEA6EA43702'
         )
+
+
+@pytest.fixture
+def updated_router():
+    controller = object()
+    router = Router(controller)
+    router.update("foo",
+                  "AHhuQ8zFQJdT8l42Axxc6m6kNwI",
+                  "MAANkj30tnFvmoh7FsjVFr+cmcs",
+                  "2011-12-16 15:11:34",
+                  "77.183.225.114",
+                  "24051", "24052")
+    return router
 
 
 class RouterTests(unittest.TestCase):
@@ -68,30 +83,6 @@ class RouterTests(unittest.TestCase):
         )
         router.flags = ['Named']
         self.assertEqual(router.unique_name, "foo")
-
-    def test_flags(self):
-        controller = object()
-        router = Router(controller)
-        router.update("foo",
-                      "AHhuQ8zFQJdT8l42Axxc6m6kNwI",
-                      "MAANkj30tnFvmoh7FsjVFr+cmcs",
-                      "2011-12-16 15:11:34",
-                      "77.183.225.114",
-                      "24051", "24052")
-        router.flags = "Exit Fast Named Running V2Dir Valid".split()
-        self.assertEqual(router.name_is_unique, True)
-
-    def test_flags_from_string(self):
-        controller = object()
-        router = Router(controller)
-        router.update("foo",
-                      "AHhuQ8zFQJdT8l42Axxc6m6kNwI",
-                      "MAANkj30tnFvmoh7FsjVFr+cmcs",
-                      "2011-12-16 15:11:34",
-                      "77.183.225.114",
-                      "24051", "24052")
-        router.flags = "Exit Fast Named Running V2Dir Valid"
-        self.assertEqual(router.name_is_unique, True)
 
     def test_policy_accept(self):
         controller = object()
@@ -173,3 +164,14 @@ class RouterTests(unittest.TestCase):
     def test_repr_no_update(self):
         router = Router(FakeController())
         repr(router)
+
+
+FLAGS_STRING = "Exit Fast Named Running V2Dir Valid"
+FLAGS = {'list': FLAGS_STRING.split(),
+         'string': FLAGS_STRING}
+
+
+@pytest.mark.parametrize('flags', FLAGS.values(), ids=FLAGS.keys())
+def test_flags(updated_router, flags):
+    updated_router.flags = flags
+    assert updated_router.name_is_unique


### PR DESCRIPTION
I now I am late for this, but is it close to what you are looking for
the GSoC project?

### Analysis

I briefly went through the `test/*.py` files and modified a few of the
simplest tests I found to use fixtures and parametrization. There are
a few points which I think that using **pytest** does improve them.

#### Readability

In my opinion, convention over configuration is usually confusing for
people that do not know the conventions, but once you know them, it
gets a lot better than having lots of boilerplate code that you
already know what is doing.

#### Loops

A couple tests were using for loops to make a test run against a set
of values. The problem with that is that if one of the values fails,
the whole test fails and depending on the error it might not be so
easy to understand it. Using parametrized functions/fixtures removes
the for loops complexity and a test for each value is run, so that it
is simple to find out which value caused the failure, especially due
to the test ID:

    # previous
    test_util.py::TestUnescapeQuotedString::test_invalid_string_unescaping FAILED
    
    # current
    test_util.py::test_invalid_string_unescaping[None] FAILED
    test_util.py::test_invalid_string_unescaping["""] PASSED
    test_util.py::test_invalid_string_unescaping["\"] PASSED
    test_util.py::test_invalid_string_unescaping["\\\"] PASSED
    test_util.py::test_invalid_string_unescaping["\\""] PASSED

Another case which that might not apply is the
`test_string_unescape_octals` method, where it runs 1000 assertions
and parametrizing that would result in 1000 tests, making it harder to
read the output.

#### Assertion messages

Notice that I removed the `msg` string from the
`test_valid_string_unescaping` function because **pytest** displays
the values that failed the assertion:

    >       assert unescaped == correct_unescaped
    E       assert 'None' == None

#### Object reuse

The `test_router.py` file has the following lines:

    controller = object()
    router = Router(controller)
    router.update("foo",
                  "AHhuQ8zFQJdT8l42Axxc6m6kNwI",
                  "MAANkj30tnFvmoh7FsjVFr+cmcs",
                  "2011-12-16 15:11:34",
                  "77.183.225.114",
                  "24051", "24052")

Which are duplicated in ~10 tests. Using the `updated_router` fixture
basically allows us to delete those 8 lines from each test case. It 
might not be the case, but that fixture can also be parametrized,
creating even more tests with less code.

#### Function reuse

The `test_valid_lookup_versions` function replaced the
`test_valid_lookup_v2` and `test_valid_lookup_v3` methods using a
parametrized fixture, saving lines of code and preventing a future
reader from reading almost the same code twice.

#### Lines of code

This commit actually has more additions than deletions (+103/-100)
and 3 more lines than previously, but based on the topics mentioned
above, I think **pytest** improved the quality of the tests. Also, I
like to think that there is only extra code due to the imports, double
line spacing of the main indentation level and creation of constants
that could have been avoided by passing the values directly to the
parameters, but in my opinion makes the code more readable.

### Background

I honestly do not have experience with either **Twisted** nor
**txtorcon** and I am currently learning **pytest** for my senior
design project, but I am interested in the project. Can the schedule
include time to study such things, or it is expected of students to
know how everything they are going to do?

Let me know what you think and what you expect for the whole project.
For example, what other tools do you expect to use? I am aware of the
[pytest-twisted] package, which might help but does not seem to be
popular.

Last thing: what do you have in mind for the `TestCase` classes? Are
they going to be completely replaced?

Thanks!

[pytest-twisted]: https://pypi.python.org/pypi/pytest-twisted
