### PR TITLE
Fix circuit.age default-value

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -21,6 +21,8 @@ unreleased
 
 `git master <https://github.com/meejah/txtorcon>`_ *will likely become v0.16.0*
 
+ * fix `issue 179 <https://github.com/meejah/txtorcon/issues/179>`_ with `Circuit.age`.
+
 
 v0.15.0
 -------

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -4,6 +4,7 @@ from twisted.trial import unittest
 from twisted.internet import defer, task
 from twisted.python.failure import Failure
 from zope.interface import implements
+from mock import patch
 
 from txtorcon import Circuit
 from txtorcon import build_timeout_circuit
@@ -103,6 +104,22 @@ class CircuitTests(unittest.TestCase):
         circuit.update(update.split())
         diff = circuit.age(now=now)
         self.assertEquals(diff, 0)
+        self.assertTrue(circuit.time_created is not None)
+
+    @patch('txtorcon.circuit.datetime')
+    def test_age_default(self, fake_datetime):
+        """
+        age() w/ defaults works properly
+        """
+        from datetime import datetime
+        now = datetime.fromtimestamp(60.0)
+        fake_datetime.return_value = now
+        fake_datetime.utcnow = Mock(return_value=now)
+        tor = FakeTorController()
+
+        circuit = Circuit(tor)
+        circuit._time_created = datetime.fromtimestamp(0.0)
+        self.assertEquals(circuit.age(), 60)
         self.assertTrue(circuit.time_created is not None)
 
     def test_no_age_yet(self):

--- a/txtorcon/circuit.py
+++ b/txtorcon/circuit.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 from __future__ import with_statement
 
 import time
-import datetime
+from datetime import datetime
 
 from twisted.python.failure import Failure
 from twisted.python import log
@@ -119,7 +119,7 @@ class Circuit(object):
             # strip off milliseconds
             t = self.flags['TIME_CREATED'].split('.')[0]
             tstruct = time.strptime(t, TIME_FORMAT)
-            self._time_created = datetime.datetime(*tstruct[:7])
+            self._time_created = datetime(*tstruct[:7])
         return self._time_created
 
     def listen(self, listener):
@@ -153,7 +153,7 @@ class Circuit(object):
         d.addCallback(close_command_is_queued)
         return self._closing_deferred
 
-    def age(self, now=datetime.datetime.utcnow()):
+    def age(self, now=None):
         """
         Returns an integer which is the difference in seconds from
         'now' to when this circuit was created.
@@ -162,6 +162,8 @@ class Circuit(object):
         """
         if not self.time_created:
             return None
+        if now is None:
+            now = datetime.utcnow()
         return (now - self.time_created).seconds
 
     def _create_flags(self, kw):


### PR DESCRIPTION
The defaults for kwargs are computed at import time, which
was not the intent of this method when defaulting now=