### PR TITLE
Add socks_endpoint kwarg to TorClientEndpoint's constructor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Twisted>=11.1.0
 ipaddress>=1.0.16
 zope.interface>=3.6.1
 txsocksx>=1.13.0
+pyopenssl>=16.1.0

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -592,10 +592,11 @@ class TestTorClientEndpoint(unittest.TestCase):
         This test is equivalent to txsocksx's
         TestSOCKS4ClientEndpoint.test_clientConnectionFailed
         """
-        def fail_tor_socks_endpoint_generator(*args, **kw):
-            kw['failure'] = Failure(ConnectionRefusedError())
-            return FakeTorSocksEndpoint(*args, **kw)
-        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=fail_tor_socks_endpoint_generator)
+        args = "host123"
+        kw = dict()
+        kw['failure'] = Failure(ConnectionRefusedError())
+        tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
+        endpoint = TorClientEndpoint('', 0, socks_endpoint=tor_endpoint)
         d = endpoint.connect(None)
         return self.assertFailure(d, ConnectionRefusedError)
 
@@ -603,19 +604,16 @@ class TestTorClientEndpoint(unittest.TestCase):
         """
         Same as above, but with a username/password.
         """
-        def fail_tor_socks_endpoint_generator(*args, **kw):
-            kw['failure'] = Failure(ConnectionRefusedError())
-            return FakeTorSocksEndpoint(*args, **kw)
+        args = "fakehost"
+        kw = dict()
+        kw['failure'] = Failure(ConnectionRefusedError())
+        tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
         endpoint = TorClientEndpoint(
             'invalid host', 0,
             socks_username='billy', socks_password='s333cure',
-            _proxy_endpoint_generator=fail_tor_socks_endpoint_generator)
+            socks_endpoint = tor_endpoint)
         d = endpoint.connect(None)
         return self.assertFailure(d, ConnectionRefusedError)
-
-    def test_default_generator(self):
-        # just ensuring the default generator doesn't blow up
-        default_tcp4_endpoint_generator(None, 'foo.bar', 1234)
 
     def test_no_host(self):
         self.assertRaises(
@@ -644,15 +642,13 @@ class TestTorClientEndpoint(unittest.TestCase):
         """
         This test is equivalent to txsocksx's TestSOCKS5ClientEndpoint.test_defaultFactory
         """
-        endpoints = []
 
-        def tor_socks_endpoint_generator(*args, **kw):
-            endpoints.append(FakeTorSocksEndpoint(*args, **kw))
-            return endpoints[-1]
-        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=tor_socks_endpoint_generator)
+        args = "fakehost"
+        kw = dict()
+        tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
+        endpoint = TorClientEndpoint('', 0, socks_endpoint=tor_endpoint)
         endpoint.connect(Mock)
-        self.assertEqual(1, len(endpoints))
-        self.assertEqual(endpoints[0].transport.value(), '\x05\x01\x00')
+        self.assertEqual(tor_endpoint.transport.value(), '\x05\x01\x00')
 
     @patch('txtorcon.endpoints.SOCKS5ClientEndpoint')
     @defer.inlineCallbacks
@@ -661,11 +657,10 @@ class TestTorClientEndpoint(unittest.TestCase):
         gold_proto = object()
         ep.connect = MagicMock(return_value=gold_proto)
         socks5_factory.return_value = ep
-
-        def tor_socks_endpoint_generator(*args, **kw):
-            return FakeTorSocksEndpoint(*args, **kw)
-
-        endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=tor_socks_endpoint_generator)
+        args = "fakehost"
+        kw = dict()
+        tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
+        endpoint = TorClientEndpoint('', 0, socks_endpoint = tor_endpoint)
         other_proto = yield endpoint.connect(MagicMock())
         self.assertEqual(other_proto, gold_proto)
 
@@ -677,16 +672,15 @@ class TestTorClientEndpoint(unittest.TestCase):
         proxy endpoint for each port that the Tor client endpoint will try.
         """
         success_ports = TorClientEndpoint.socks_ports_to_try
-        endpoints = []
         for port in success_ports:
-            def tor_socks_endpoint_generator(*args, **kw):
-                kw['accept_port'] = port
-                kw['failure'] = Failure(ConnectionRefusedError())
-                endpoints.append(FakeTorSocksEndpoint(*args, **kw))
-                return endpoints[-1]
-            endpoint = TorClientEndpoint('', 0, _proxy_endpoint_generator=tor_socks_endpoint_generator)
+            args = "fakehost"
+            kw = dict()
+            kw['accept_port'] = port
+            kw['failure'] = Failure(ConnectionRefusedError())
+            tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
+            endpoint = TorClientEndpoint('', 0)
             endpoint.connect(None)
-            self.assertEqual(endpoints[-1].transport.value(), '\x05\x01\x00')
+            self.assertEqual(tor_endpoint.transport.value(), '\x05\x01\x00')
 
     def test_bad_port_retry(self):
         """

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -673,12 +673,13 @@ class TestTorClientEndpoint(unittest.TestCase):
         """
         success_ports = TorClientEndpoint.socks_ports_to_try
         for port in success_ports:
-            args = "fakehost"
-            kw = dict()
-            kw['accept_port'] = port
-            kw['failure'] = Failure(ConnectionRefusedError())
-            tor_endpoint = FakeTorSocksEndpoint(*args, **kw)
-            endpoint = TorClientEndpoint('', 0)
+            tor_endpoint = FakeTorSocksEndpoint(
+                "fakehost", "127.0.0.1", port,
+                accept_port=port,
+                failure=Failure(ConnectionRefusedError()),
+            )
+
+            endpoint = TorClientEndpoint('', 0, socks_endpoint=tor_endpoint)
             endpoint.connect(None)
             self.assertEqual(tor_endpoint.transport.value(), '\x05\x01\x00')
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -34,7 +34,6 @@ from txtorcon import IProgressProvider
 from txtorcon import TorOnionAddress
 from txtorcon.util import NoOpProtocolFactory
 from txtorcon.endpoints import get_global_tor                       # FIXME
-from txtorcon.endpoints import default_tcp4_endpoint_generator
 
 import util
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -626,7 +626,8 @@ class TestTorClientEndpoint(unittest.TestCase):
 
         self.assertEqual(ep.host, 'timaq4ygg2iegci7.onion')
         self.assertEqual(ep.port, 80)
-        self.assertEqual(ep.socks_port, 9050)
+        # XXX what's "the Twisted way" to get the port out here?
+        self.assertEqual(ep.socks_endpoint._port, 9050)
 
     def test_parser_user_password(self):
         epstring = 'tor:host=torproject.org:port=443' + \

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -32,7 +32,6 @@ from twisted.internet.interfaces import IAddress
 from twisted.internet.endpoints import serverFromString
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.endpoints import TCP4ClientEndpoint
-from twisted.internet.endpoints import UNIXClientEndpoint
 from twisted.internet import error
 from twisted.plugin import IPlugin
 from twisted.python.util import FancyEqMixin
@@ -668,7 +667,7 @@ class TorClientEndpoint(object):
     socks_ports_to_try = [9050, 9150]
 
     def __init__(self, host, port,
-                 socks_socket=None,
+                 socks_endpoint=None,
                  socks_hostname=None, socks_port=None,
                  socks_username=None, socks_password=None,
                  _proxy_endpoint_generator=default_tcp4_endpoint_generator):
@@ -678,7 +677,7 @@ class TorClientEndpoint(object):
         self.host = host
         self.port = int(port)
         self._proxy_endpoint_generator = _proxy_endpoint_generator
-        self.socks_socket = socks_socket
+        self.socks_endpoint = socks_endpoint
         self.socks_hostname = socks_hostname
         self.socks_port = int(socks_port) if socks_port is not None else None
         self.socks_username = socks_username
@@ -694,9 +693,8 @@ class TorClientEndpoint(object):
     @defer.inlineCallbacks
     def connect(self, protocolfactory):
         last_error = None
-        if self.socks_socket is not None:
-            tor_ep = UNIXClientEndpoint(reactor, self.socks_socket)
-            args = (self.host, self.port, tor_ep)
+        if self.socks_endpoint is not None:
+            args = (self.host, self.port, self.socks_endpoint)
             kwargs = dict()
             socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
             proto = yield socks_ep.connect(protocolfactory)

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -677,7 +677,6 @@ class TorClientEndpoint(object):
             except KeyError:
                 pass
 
-        if self.socks_endpoint is None:
             self._socks_port_iter = iter(self.socks_ports_to_try)
             self._socks_guessing_enabled = True
         else:

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -633,14 +633,6 @@ class TCPHiddenServiceEndpointParser(object):
                                                    control_port=controlPort)
 
 
-def default_tcp4_endpoint_generator(*args, **kw):
-    """
-    Default generator used to create client-side TCP4ClientEndpoint
-    instances.  We do this to make the unit tests work...
-    """
-    return TCP4ClientEndpoint(*args, **kw)
-
-
 @implementer(IStreamClientEndpoint)
 class TorClientEndpoint(object):
     """

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -693,9 +693,16 @@ class TorClientEndpoint(object):
     @defer.inlineCallbacks
     def connect(self, protocolfactory):
         last_error = None
+
+        kwargs = dict()
+        if self.socks_username is not None and self.socks_password is not None:
+            kwargs['methods'] = dict(
+                login=(self.socks_username, self.socks_password),
+            )
+
+
         if self.socks_endpoint is not None:
             args = (self.host, self.port, self.socks_endpoint)
-            kwargs = dict()
             socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
             proto = yield socks_ep.connect(protocolfactory)
             defer.returnValue(proto)
@@ -707,14 +714,7 @@ class TorClientEndpoint(object):
                     self.socks_hostname,
                     self.socks_port,
                 )
-
                 args = (self.host, self.port, tor_ep)
-                kwargs = dict()
-                if self.socks_username is not None and self.socks_password is not None:
-                    kwargs['methods'] = dict(
-                        login=(self.socks_username, self.socks_password),
-                    )
-
                 socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
 
                 try:

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -770,10 +770,14 @@ class TorClientEndpointStringParser(object):
         if socksPort is not None:
             socksPort = int(socksPort)
 
+        ep = None
+        if socksPort is not None:
+            ep = TCP4ClientEndpoint(reactor, socksHostname, socksPort)
         return TorClientEndpoint(
             host, port,
-            socks_hostname=socksHostname, socks_port=socksPort,
-            socks_username=socksUsername, socks_password=socksPassword
+            socks_endpoint=ep,
+            socks_username=socksUsername,
+            socks_password=socksPassword,
         )
 
     def parseStreamClient(self, *args, **kwargs):

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -668,7 +668,7 @@ class TorClientEndpoint(object):
 
     def __init__(self, host, port,
                  socks_endpoint=None,
-                 socks_username=None, socks_password=None):
+                 socks_username=None, socks_password=None, **kw):
         if host is None or port is None:
             raise ValueError('host and port must be specified')
 
@@ -677,6 +677,15 @@ class TorClientEndpoint(object):
         self.socks_endpoint = socks_endpoint
         self.socks_username = socks_username
         self.socks_password = socks_password
+
+        # backwards-compatibility: you used to specify a TCP SOCKS
+        # endpoint via socks_host= and socks_port= kwargs
+        if self.socks_endpoint is None:
+            try:
+                self.socks_endpoint = TCP4ClientEndpoint(reactor, kw['socks_host'], kw['socks_port'])
+                # XXX should deprecation-warn here
+            except KeyError:
+                pass
 
         if self.socks_endpoint is None:
             self._socks_port_iter = iter(self.socks_ports_to_try)

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -32,6 +32,7 @@ from twisted.internet.interfaces import IAddress
 from twisted.internet.endpoints import serverFromString
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import UNIXClientEndpoint
 from twisted.internet import error
 from twisted.plugin import IPlugin
 from twisted.python.util import FancyEqMixin
@@ -667,6 +668,7 @@ class TorClientEndpoint(object):
     socks_ports_to_try = [9050, 9150]
 
     def __init__(self, host, port,
+                 socks_socket=None,
                  socks_hostname=None, socks_port=None,
                  socks_username=None, socks_password=None,
                  _proxy_endpoint_generator=default_tcp4_endpoint_generator):
@@ -676,6 +678,7 @@ class TorClientEndpoint(object):
         self.host = host
         self.port = int(port)
         self._proxy_endpoint_generator = _proxy_endpoint_generator
+        self.socks_socket = socks_socket
         self.socks_hostname = socks_hostname
         self.socks_port = int(socks_port) if socks_port is not None else None
         self.socks_username = socks_username
@@ -691,31 +694,39 @@ class TorClientEndpoint(object):
     @defer.inlineCallbacks
     def connect(self, protocolfactory):
         last_error = None
-        for socks_port in self._socks_port_iter:
-            self.socks_port = socks_port
-            tor_ep = self._proxy_endpoint_generator(
-                reactor,
-                self.socks_hostname,
-                self.socks_port,
-            )
-
+        if self.socks_socket is not None:
+            tor_ep = UNIXClientEndpoint(reactor, self.socks_socket)
             args = (self.host, self.port, tor_ep)
             kwargs = dict()
-            if self.socks_username is not None and self.socks_password is not None:
-                kwargs['methods'] = dict(
-                    login=(self.socks_username, self.socks_password),
+            socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
+            proto = yield socks_ep.connect(protocolfactory)
+            defer.returnValue(proto)
+        else:
+            for socks_port in self._socks_port_iter:
+                self.socks_port = socks_port
+                tor_ep = self._proxy_endpoint_generator(
+                    reactor,
+                    self.socks_hostname,
+                    self.socks_port,
                 )
 
-            socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
+                args = (self.host, self.port, tor_ep)
+                kwargs = dict()
+                if self.socks_username is not None and self.socks_password is not None:
+                    kwargs['methods'] = dict(
+                        login=(self.socks_username, self.socks_password),
+                    )
 
-            try:
-                proto = yield socks_ep.connect(protocolfactory)
-                defer.returnValue(proto)
+                socks_ep = SOCKS5ClientEndpoint(*args, **kwargs)
 
-            except error.ConnectError as e0:
-                last_error = e0
-        if last_error is not None:
-            raise last_error
+                try:
+                    proto = yield socks_ep.connect(protocolfactory)
+                    defer.returnValue(proto)
+
+                except error.ConnectError as e0:
+                    last_error = e0
+            if last_error is not None:
+                raise last_error
 
 
 @implementer(IPlugin, IStreamClientEndpointStringParserWithReactor)


### PR DESCRIPTION

this adds UNIX domain socket functionality to the TorClientEndpoint... so that we connect to the SOCKS proxy via a unix domain socket.