### PR TITLE
Addrmap stream improvement

### DIFF
--- a/docs/release-checklist.rst
+++ b/docs/release-checklist.rst
@@ -83,9 +83,12 @@ Release Checklist
            meejah
 
 * copy release announcement to signing machine, update code
+   * (from dev machine: "git push pangea")
+   * git checkout master
+   * git pull
 
 * create signed tag
-   * git tag -s -u meejah@meejah.ca -F path/to/release-announcement-X-Y-Z v${VERSION}
+   * git tag -s -u meejah@meejah.ca -F release-announce-${VERSION} v${VERSION}
 
 * copy dist/* files + signatures to hidden-service machine
 * copy them to the HTML build directory! (docs/_build/html/)

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -100,7 +100,7 @@ class CircuitTests(unittest.TestCase):
 
         circuit = Circuit(tor)
         now = datetime.datetime.now()
-        update = '1 LAUNCHED PURPOSE=GENERAL TIME_CREATED=%s' % time.strftime('%Y-%m-%dT%H:%M:%S')
+        update = '1 LAUNCHED PURPOSE=GENERAL TIME_CREATED=%s' % now.strftime('%Y-%m-%dT%H:%M:%S')
         circuit.update(update.split())
         diff = circuit.age(now=now)
         self.assertEquals(diff, 0)

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -7,6 +7,7 @@ from txtorcon import Stream
 from txtorcon import IStreamListener
 from txtorcon import ICircuitContainer
 from txtorcon import StreamListenerMixin
+from txtorcon import AddrMap
 
 
 class FakeCircuit:
@@ -135,6 +136,13 @@ class StreamTests(unittest.TestCase):
         errors = self.flushLoggedErrors()
         self.assertEqual(1, len(errors))
         self.assertEqual(errors[0].value, exc)
+
+    def test_stream_addrmap_remap(self):
+        addrmap = AddrMap()
+        addrmap.update('meejah.ca 1.2.3.4 never')
+        stream = Stream(self, addrmap)
+        stream.update("1604 NEW 0 1.2.3.4:0 PURPOSE=DNS_REQUEST".split())
+        self.assertEqual(stream.target_host, "meejah.ca")
 
     def test_circuit_already_valid_in_new(self):
         stream = Stream(self)

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -119,6 +119,23 @@ class StreamTests(unittest.TestCase):
             args = [None] * len(desc.positional)
             method(*args)
 
+    def test_listener_exception(self):
+        """A listener throws an exception during notify"""
+
+        exc = Exception("the bad stuff happened")
+        class Bad(StreamListenerMixin):
+            def stream_new(*args, **kw):
+                raise exc
+        listener = Bad()
+
+        stream = Stream(self)
+        stream.listen(listener)
+        stream.update("1 NEW 0 94.23.164.42.$43ED8310EB968746970896E8835C2F1991E50B69.exit:9001 SOURCE_ADDR=(Tor_internal):0 PURPOSE=DIR_FETCH".split())
+
+        errors = self.flushLoggedErrors()
+        self.assertEqual(1, len(errors))
+        self.assertEqual(errors[0].value, exc)
+
     def test_circuit_already_valid_in_new(self):
         stream = Stream(self)
         stream.circuit = FakeCircuit(1)

--- a/test/test_torstate.py
+++ b/test/test_torstate.py
@@ -438,9 +438,15 @@ class StateTests(unittest.TestCase):
 
         self.send("250 OK")
 
-        self.assertEqual(len(self.state.addrmap.addr), 2)
+        self.assertEqual(len(self.state.addrmap.addr), 4)
         self.assertTrue('www.example.com' in self.state.addrmap.addr)
         self.assertTrue('subdomain.example.com' in self.state.addrmap.addr)
+        self.assertTrue('10.0.0.0' in self.state.addrmap.addr)
+        self.assertTrue('127.0.0.1' in self.state.addrmap.addr)
+        self.assertEqual('127.0.0.1', self.state.addrmap.find('www.example.com').ip)
+        self.assertEqual('www.example.com', self.state.addrmap.find('127.0.0.1').name)
+        self.assertEqual('10.0.0.0', self.state.addrmap.find('subdomain.example.com').ip)
+        self.assertEqual('subdomain.example.com', self.state.addrmap.find('10.0.0.0').name)
 
         return d
 

--- a/txtorcon/addrmap.py
+++ b/txtorcon/addrmap.py
@@ -124,7 +124,9 @@ class AddrMap(object):
 
         else:
             a = Addr(self)
+            # add both name and IP address
             self.addr[params[0]] = a
+            self.addr[params[1]] = a
             a.update(*params)
             self.notify("addrmap_added", *[a], **{})
 

--- a/txtorcon/stream.py
+++ b/txtorcon/stream.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 from __future__ import with_statement
 
 from twisted.python import log
+from twisted.python.failure import Failure
 from twisted.internet import defer
 from txtorcon.interface import ICircuitContainer, IStreamListener
 from txtorcon.util import find_keywords, maybe_ip_addr
@@ -195,9 +196,9 @@ class Stream(object):
             if self.state == 'NEW':
                 if self.circuit is not None:
                     log.err(RuntimeError("Weird: circuit valid in NEW"))
-                [x.stream_new(self) for x in self.listeners]
+                self._notify('stream_new', self)
             else:
-                [x.stream_succeeded(self) for x in self.listeners]
+                self._notify('stream_succeeded', self)
 
         elif self.state == 'REMAP':
             self.target_addr = maybe_ip_addr(args[3][:args[3].rfind(':')])
@@ -208,7 +209,7 @@ class Stream(object):
             self.circuit = None
             self.maybe_call_closing_deferred()
             flags = self._create_flags(kw)
-            [x.stream_closed(self, **flags) for x in self.listeners]
+            self._notify('stream_closed', self, **flags)
 
         elif self.state == 'FAILED':
             if self.circuit:
@@ -217,7 +218,7 @@ class Stream(object):
             self.maybe_call_closing_deferred()
             # build lower-case version of all flags
             flags = self._create_flags(kw)
-            [x.stream_failed(self, **flags) for x in self.listeners]
+            self._notify('stream_failed', self, **flags)
 
         elif self.state == 'SENTCONNECT':
             pass  # print 'SENTCONNECT',self,args
@@ -230,7 +231,7 @@ class Stream(object):
             # FIXME does this count as closed?
             # self.maybe_call_closing_deferred()
             flags = self._create_flags(kw)
-            [x.stream_detach(self, **flags) for x in self.listeners]
+            self._notify('stream_detach', self, **flags)
 
         elif self.state in ['NEWRESOLVE', 'SENTRESOLVE']:
             pass  # print self.state, self, args
@@ -253,8 +254,7 @@ class Stream(object):
                     self.circuit = self.circuit_container.find_circuit(cid)
                     if self not in self.circuit.streams:
                         self.circuit.streams.append(self)
-                        for x in self.listeners:
-                            x.stream_attach(self, self.circuit)
+                        self._notify('stream_attach', self, self.circuit)
 
                 else:
                     if self.circuit.id != cid:
@@ -264,6 +264,18 @@ class Stream(object):
                                 (self.circuit.id, cid)
                             )
                         )
+
+    def _notify(self, func, *args, **kw):
+        """
+        Internal helper. Calls the IStreamListener function 'func' with
+        the given args, guarding around errors.
+        """
+        for x in self.listeners:
+            try:
+                getattr(x, func)(*args, **kw)
+            except Exception:
+                f = Failure()
+                print("Error calling '{}' on '{}': {}".format(func, x, f.getBriefTraceback()))
 
     def maybe_call_closing_deferred(self):
         """

--- a/txtorcon/stream.py
+++ b/txtorcon/stream.py
@@ -285,8 +285,7 @@ class Stream(object):
             try:
                 getattr(x, func)(*args, **kw)
             except Exception:
-                f = Failure()
-                print("Error calling '{}' on '{}': {}".format(func, x, f.getBriefTraceback()))
+                log.err()
 
     def maybe_call_closing_deferred(self):
         """

--- a/txtorcon/torstate.py
+++ b/txtorcon/torstate.py
@@ -788,10 +788,11 @@ class TorState(object):
         stream_id = int(args[0])
         wasnew = False
         if stream_id not in self.streams:
-            stream = self.stream_factory(self)
+            stream = self.stream_factory(self, self.addrmap)
             self.streams[stream_id] = stream
             stream.listen(self)
-            [stream.listen(x) for x in self.stream_listeners]
+            for x in self.stream_listeners:
+                stream.listen(x)
             wasnew = True
         self.streams[stream_id].update(args)
 


### PR DESCRIPTION
Using list-comprehensions to do the notifications might look nice, but isn't very robust.

Also, re-map Stream.target_host from IP back to hostname, whenever possible (should be "always").