### PR TITLE
Attacher API

### DIFF
--- a/examples/web_client_custom_circuit.py
+++ b/examples/web_client_custom_circuit.py
@@ -1,0 +1,83 @@
+# this example shows how to use specific circuits over Tor (with
+# Twisted's web client or with a custom protocol)
+#
+# NOTE WELL: this functionality is for advanced use-cases and if you
+# do anything "special" to select your circuit hops you risk making it
+# easy to de-anonymize this (and all other) Tor circuits.
+
+from __future__ import print_function
+
+from twisted.internet.protocol import Protocol, Factory
+from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.internet.task import react
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.web.client import readBody
+
+import txtorcon
+from txtorcon.util import default_control_port
+
+
+@inlineCallbacks
+def main(reactor):
+    # use port 9051 for system tor instances, or:
+    # ep = UNIXClientEndpoint(reactor, '/var/run/tor/control')
+    ep = TCP4ClientEndpoint(reactor, '127.0.0.1', default_control_port())
+    tor = yield txtorcon.connect(reactor, ep)
+    print("Connected:", tor)
+
+    state = yield tor.create_state()
+    socks = tor.config.socks_endpoint(reactor)
+
+    # create a custom circuit; in this case we're just letting Tor
+    # decide the path but you *can* select a path (again: for advanced
+    # use cases that will probably de-anonymize you)
+    circ = yield state.build_circuit()
+    print("Building a circuit:", circ)
+
+    # at this point, the circuit will be "under way" but may not yet
+    # be in BUILT state -- and hence usable. So, we wait.
+    yield circ.when_built()
+    print("Circuit is ready:", circ)
+
+    if False:
+        # create a web.Agent that will use this circuit (or fail)
+        agent = circ.web_agent(reactor, socks)
+
+        uri = 'https://www.torproject.org'
+        print("Downloading {}".format(uri))
+        resp = yield agent.request('GET', uri)
+
+        print("Response has {} bytes".format(resp.length))
+        body = yield readBody(resp)
+        print("received body ({} bytes)".format(len(body)))
+        print("{}\n[...]\n{}\n".format(body[:200], body[-200:]))
+
+    if True:
+        # make a plain TCP connection to a thing
+        ep = circ.stream_via(reactor, 'torproject.org', 80)
+
+        d = Deferred()
+
+        class ToyWebRequestProtocol(Protocol):
+
+            def connectionMade(self):
+                print("Connected via {}".format(self.transport.getHost()))
+                self.transport.write(
+                    'GET http://torproject.org/ HTTP/1.1\r\n'
+                    'Host: torproject.org\r\n'
+                    '\r\n'
+                )
+
+            def dataReceived(self, d):
+                print("  received {} bytes".format(len(d)))
+
+            def connectionLost(self, reason):
+                print("disconnected")
+                d.callback(reason)
+
+        proto = yield ep.connect(Factory.forProtocol(ToyWebRequestProtocol))
+        yield d
+        print("All done, closing the circuit")
+        yield circ.close()
+
+react(main)

--- a/examples/web_client_treq.py
+++ b/examples/web_client_treq.py
@@ -1,0 +1,42 @@
+# just copying over most of "carml checkpypi" because it's a good
+# example of "I want a stream over *this* circuit".
+
+from __future__ import print_function
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.internet.task import react
+from twisted.internet.endpoints import TCP4ClientEndpoint
+
+import txtorcon
+from txtorcon.util import default_control_port
+
+try:
+    import treq
+except ImportError:
+    print("To use this example, please install 'treq':")
+    print("pip install treq")
+    raise SystemExit(1)
+
+
+@inlineCallbacks
+def main(reactor):
+    ep = TCP4ClientEndpoint(reactor, '127.0.0.1', default_control_port())
+    # ep = UNIXClientEndpoint(reactor, '/var/run/tor/control')
+    tor = yield txtorcon.connect(reactor, ep)
+    print("Connected:", tor)
+
+    resp = yield treq.get(
+        'https://www.torproject.org:443',
+        agent=tor.web_agent(),
+    )
+
+    print("Retrieving {} bytes".format(resp.length))
+    data = yield resp.text()
+    print("Got {} bytes:\n{}\n[...]{}".format(
+        len(data),
+        data[:120],
+        data[-120:],
+    ))
+
+
+react(main)

--- a/test/test_attacher.py
+++ b/test/test_attacher.py
@@ -1,9 +1,7 @@
 from mock import Mock
-from datetime import datetime
 from zope.interface import directlyProvides
 
 from twisted.trial import unittest
-from twisted.internet import defer
 
 from txtorcon.attacher import PriorityAttacher
 from txtorcon.interface import IStreamAttacher

--- a/test/test_attacher.py
+++ b/test/test_attacher.py
@@ -1,0 +1,43 @@
+from mock import Mock
+from datetime import datetime
+from zope.interface import directlyProvides
+
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from txtorcon.attacher import PriorityAttacher
+from txtorcon.interface import IStreamAttacher
+
+
+class PriorityAttacherTest(unittest.TestCase):
+
+    def test_add_remove(self):
+        a = PriorityAttacher()
+        boom = Mock()
+        directlyProvides(boom, IStreamAttacher)
+
+        a.add_attacher(boom)
+        a.remove_attacher(boom)
+        with self.assertRaises(ValueError) as ctx:
+            a.remove_attacher(boom)
+        self.assertTrue('not found' in str(ctx.exception))
+
+    def test_stream_failure(self):
+        a = PriorityAttacher()
+        boom = Mock()
+        directlyProvides(boom, IStreamAttacher)
+
+        a.add_attacher(boom)
+        a.attach_stream_failure(Mock(), Mock())
+
+    def test_attach_stream(self):
+        a = PriorityAttacher()
+        boom = Mock()
+        directlyProvides(boom, IStreamAttacher)
+
+        a.add_attacher(boom)
+        a.attach_stream(Mock(), [])
+
+    def test_attach_stream_nothing(self):
+        a = PriorityAttacher()
+        a.attach_stream(Mock(), [])

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -12,7 +12,7 @@ from txtorcon import TorControlProtocol
 from txtorcon import TorState
 from txtorcon import Router
 from txtorcon.router import hexIdFromHash
-from txtorcon.circuit import TorCircuitEndpoint
+from txtorcon.circuit import TorCircuitEndpoint, _get_circuit_attacher
 from txtorcon.interface import IRouterContainer
 from txtorcon.interface import ICircuitListener
 from txtorcon.interface import ICircuitContainer
@@ -95,10 +95,13 @@ examples = ['CIRC 365 LAUNCHED PURPOSE=GENERAL',
 
 class TestCircuitEndpoint(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def test_attach(self):
+
         @implementer(ICircuitContainer)
         class FakeContainer(object):
             pass
+
         container = FakeContainer()
         stream = Stream(container)
         circuit = Mock()
@@ -113,7 +116,8 @@ class TestCircuitEndpoint(unittest.TestCase):
             reactor, state, circuit, target_endpoint, got_source,
         )
 
-        endpoint.attach_stream(stream, [])
+        attacher = yield _get_circuit_attacher(reactor, state)
+        attacher.attach_stream(stream, [])
 
 
 class CircuitTests(unittest.TestCase):

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -110,10 +110,9 @@ class TestCircuitEndpoint(unittest.TestCase):
         state = Mock()
         addr = Mock()
         addr.host = 'foo.com'
-        got_source = defer.succeed(addr)
 
         TorCircuitEndpoint(
-            reactor, state, circuit, target_endpoint, got_source,
+            reactor, state, circuit, target_endpoint,
         )
 
         attacher = yield _get_circuit_attacher(reactor, state)

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -119,6 +119,24 @@ class TestCircuitEndpoint(unittest.TestCase):
         attacher.attach_stream(stream, [])
         # hmmm, no assert??
 
+    @defer.inlineCallbacks
+    def test_attach_failure_unfound(self):
+
+        @implementer(ICircuitContainer)
+        class FakeContainer(object):
+            pass
+
+        reactor = Mock()
+        container = FakeContainer()
+        stream = Stream(container)
+        state = Mock()
+        addr = Mock()
+        addr.host = 'foo.com'
+
+        attacher = yield _get_circuit_attacher(reactor, state)
+        attacher.attach_stream_failure(stream, None)
+        # no assert; just making sure this doesn't explode
+
 
 class CircuitTests(unittest.TestCase):
 

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -112,12 +112,13 @@ class TestCircuitEndpoint(unittest.TestCase):
         addr.host = 'foo.com'
         got_source = defer.succeed(addr)
 
-        endpoint = TorCircuitEndpoint(
+        TorCircuitEndpoint(
             reactor, state, circuit, target_endpoint, got_source,
         )
 
         attacher = yield _get_circuit_attacher(reactor, state)
         attacher.attach_stream(stream, [])
+        # hmmm, no assert??
 
 
 class CircuitTests(unittest.TestCase):
@@ -232,7 +233,8 @@ class CircuitTests(unittest.TestCase):
         circuit.update('1 CLOSED $E11D2B2269CC25E67CA6C9FB5843497539A74FD0=eris,$50DD343021E509EB3A5A7FD0D8A4F8364AFBDCB5=venus,$253DFF1838A2B7782BE7735F74E50090D46CA1BC=chomsky PURPOSE=GENERAL REASON=FINISHED'.split())
         circuit.update('1 FAILED $E11D2B2269CC25E67CA6C9FB5843497539A74FD0=eris,$50DD343021E509EB3A5A7FD0D8A4F8364AFBDCB5=venus,$253DFF1838A2B7782BE7735F74E50090D46CA1BC=chomsky PURPOSE=GENERAL REASON=TIMEOUT'.split())
         errs = self.flushLoggedErrors()
-        self.assertEqual(len(errs), 2)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue('Circuit is FAILED but still has 1 streams' in str(errs[0]))
 
     def test_updates(self):
         tor = FakeTorController()

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -111,7 +111,7 @@ class TestCircuitEndpoint(unittest.TestCase):
         reactor = Mock()
         state = Mock()
 
-        endpoint = TorCircuitEndpoint(
+        TorCircuitEndpoint(
             reactor, state, circuit, target_endpoint,
         )
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -201,7 +201,7 @@ class EndpointTests(unittest.TestCase):
         self.assertTrue(ding.called_with(*args))
 
     @patch('txtorcon.controller.launch')
-    def test_progress_updates_private_tor(self, tor):
+    def test_progress_updates_private_tor(self, tor, launch):
         ep = TCPHiddenServiceEndpoint.private_tor(self.reactor, 1234)
         self.assertEqual(len(tor.mock_calls), 1)
         tor.call_args[1]['progress_updates'](40, 'FOO', 'foo to the bar')

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -141,15 +141,16 @@ class EndpointTests(unittest.TestCase):
     @defer.inlineCallbacks
     def test_system_tor(self, ftb):
 
-        def boom(*args):
+        def boom():
             # why does the new_callable thing need a callable that
             # returns a callable? Feels like I must be doing something
             # wrong somewhere...
             def bam(*args, **kw):
-                return self.protocol
+                self.config.bootstrap()
+                return defer.succeed(Tor(Mock(), self.config))
             return bam
         with patch('txtorcon.endpoints.launch_tor') as launch_mock:
-            with patch('txtorcon.endpoints.build_tor_connection', new_callable=boom):
+            with patch('txtorcon.controller.connect', new_callable=boom):
                 client = clientFromString(
                     self.reactor,
                     "tcp:host=localhost:port=9050"
@@ -788,7 +789,7 @@ class TestTorClientEndpoint(unittest.TestCase):
         self.assertEqual(ep.host, 'timaq4ygg2iegci7.onion')
         self.assertEqual(ep.port, 80)
         # XXX what's "the Twisted way" to get the port out here?
-        self.assertEqual(ep.socks_endpoint._port, 9050)
+        self.assertEqual(ep._socks_endpoint._port, 9050)
 
     def test_parser_user_password(self):
         epstring = 'tor:host=torproject.org:port=443' + \

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -782,13 +782,12 @@ class TestTorClientEndpoint(unittest.TestCase):
         )
 
     def test_parser_basic(self):
-        ep = clientFromString(None, 'tor:host=timaq4ygg2iegci7.onion:port=80')
+        ep = clientFromString(None, 'tor:host=timaq4ygg2iegci7.onion:port=80:socksPort=9050')
 
         self.assertEqual(ep.host, 'timaq4ygg2iegci7.onion')
         self.assertEqual(ep.port, 80)
         # XXX what's "the Twisted way" to get the port out here?
-        # XXX actually, why was this set to 9050 before? should do the guessing-thing...
-        self.assertEqual(ep._socks_endpoint, None)
+        self.assertEqual(ep._socks_endpoint._port, 9050)
 
     def test_parser_socks_port(self):
         ep = clientFromString(

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -882,6 +882,9 @@ class TestTorClientEndpoint(unittest.TestCase):
             def connect(self, *args, **kw):
                 raise ConnectionRefusedError()
 
+            def _get_address(self):
+                return defer.succeed(None)
+
         ep_mock.side_effect = FakeSocks5
         endpoint = TorClientEndpoint('', 0)
         d = endpoint.connect(Mock())
@@ -904,6 +907,9 @@ class TestTorClientEndpoint(unittest.TestCase):
             def connect(self, *args, **kw):
                 return proto
 
+            def _get_address(self):
+                return defer.succeed(None)
+
         ep_mock.side_effect = FakeSocks5
         endpoint = TorClientEndpoint('', 0)
         p2 = yield endpoint.connect(None)
@@ -922,6 +928,9 @@ class TestTorClientEndpoint(unittest.TestCase):
 
             def connect(self, *args, **kw):
                 return proto
+
+            def _get_address(self):
+                return defer.succeed(None)
 
         ep_mock.side_effect = FakeSocks5
         endpoint = TorClientEndpoint('torproject.org', 0, tls=True)
@@ -944,6 +953,9 @@ class TestTorClientEndpoint(unittest.TestCase):
 
             def connect(self, *args, **kw):
                 return proto_d
+
+            def _get_address(self):
+                return defer.succeed(None)
 
         ep_mock.side_effect = FakeSocks5
         endpoint = TorClientEndpoint(

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -18,7 +18,6 @@ from twisted.internet.interfaces import IProtocol
 from twisted.internet.interfaces import IReactorTCP
 from twisted.internet.interfaces import IListeningPort
 from twisted.internet.interfaces import IAddress
-from twisted.internet.interfaces import IStreamClientEndpoint
 
 from txtorcon import TorControlProtocol
 from txtorcon import TorConfig
@@ -202,11 +201,11 @@ class EndpointTests(unittest.TestCase):
         ep._tor_progress_update(*args)
         self.assertTrue(ding.called_with(*args))
 
-    @patch('txtorcon.controller.launch')
-    def test_progress_updates_private_tor(self, tor, launch):
+    @patch('txtorcon.endpoints.launch_tor')
+    def test_progress_updates_private_tor(self, ftb, launch):
         ep = TCPHiddenServiceEndpoint.private_tor(self.reactor, 1234)
-        self.assertEqual(len(tor.mock_calls), 1)
-        tor.call_args[1]['progress_updates'](40, 'FOO', 'foo to the bar')
+        self.assertEqual(len(ftb.mock_calls), 1)
+        ftb.call_args[1]['progress_updates'](40, 'FOO', 'foo to the bar')
         return ep
 
     def __test_progress_updates_system_tor(self):
@@ -215,7 +214,7 @@ class EndpointTests(unittest.TestCase):
         return ep
 
     @patch('txtorcon.endpoints.get_global_tor')
-    def test_progress_updates_global_tor(self, tor, ftb):
+    def test_progress_updates_global_tor(self, tor, ggt):
         ep = TCPHiddenServiceEndpoint.global_tor(self.reactor, 1234)
         tor.call_args[1]['progress_updates'](40, 'FOO', 'foo to the bar')
         return ep

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -29,7 +29,7 @@ from txtorcon import TorOnionAddress
 from txtorcon.util import NoOpProtocolFactory
 from txtorcon.util import SingleObserver
 from txtorcon.endpoints import get_global_tor                       # FIXME
-from txtorcon.circuit import TorCircuitEndpoint
+from txtorcon.circuit import TorCircuitEndpoint, _get_circuit_attacher
 from txtorcon.controller import Tor
 from txtorcon.socks import _TorSocksFactory
 
@@ -660,7 +660,7 @@ class TestTorCircuitEndpoint(unittest.TestCase):
         src_addr = Mock()
         src_addr.host = 'host'
         src_addr.port = 1234
-        target.get_address = Mock(return_value=defer.succeed(src_addr))
+        target._get_address = Mock(return_value=defer.succeed(src_addr))
         stream = Mock()
         stream.source_port = 1234
         stream.source_addr = 'host'
@@ -671,7 +671,8 @@ class TestTorCircuitEndpoint(unittest.TestCase):
 
         # should get a Failure from the connect()
         d = ep.connect(Mock())
-        yield ep.attach_stream(stream, [circ])
+        attacher = yield _get_circuit_attacher(reactor, Mock())
+        attacher.attach_stream(stream, [circ])
         try:
             yield d
             self.fail("Should get exception")
@@ -692,7 +693,7 @@ class TestTorCircuitEndpoint(unittest.TestCase):
         src_addr = Mock()
         src_addr.host = 'host'
         src_addr.port = 1234
-        target.get_address = Mock(return_value=defer.succeed(src_addr))
+        target._get_address = Mock(return_value=defer.succeed(src_addr))
         stream = Mock()
         stream.source_port = 1234
         stream.source_addr = 'host'
@@ -703,7 +704,8 @@ class TestTorCircuitEndpoint(unittest.TestCase):
 
         # should get a Failure from the connect()
         d = ep.connect(Mock())
-        ep.attach_stream_failure(stream, RuntimeError("a bad thing"))
+        attacher = yield _get_circuit_attacher(reactor, Mock())
+        attacher.attach_stream_failure(stream, RuntimeError("a bad thing"))
         try:
             yield d
             self.fail("Should get exception")
@@ -724,7 +726,7 @@ class TestTorCircuitEndpoint(unittest.TestCase):
         src_addr = Mock()
         src_addr.host = 'host'
         src_addr.port = 1234
-        target.get_address = Mock(return_value=defer.succeed(src_addr))
+        target._get_address = Mock(return_value=defer.succeed(src_addr))
         stream = Mock()
         stream.source_port = 1234
         stream.source_addr = 'host'
@@ -735,7 +737,8 @@ class TestTorCircuitEndpoint(unittest.TestCase):
 
         # should get a Failure from the connect()
         d = ep.connect(Mock())
-        yield ep.attach_stream(stream, [circ])
+        attacher = yield _get_circuit_attacher(reactor, torstate)
+        yield attacher.attach_stream(stream, [circ])
         proto = yield d
         self.assertEqual(proto, 'fake proto')
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -989,3 +989,17 @@ class TestTorClientEndpoint(unittest.TestCase):
         self.assertEqual("connectTCP", name)
         self.assertEqual("localhost", args[0])
         self.assertEqual(9050, args[1])
+
+    def test_client_endpoint_get_address(self):
+        """
+        Test the old API of passing socks_host, socks_port
+        """
+
+        reactor = Mock()
+        endpoint = TorClientEndpoint(
+            'torproject.org', 0,
+            socks_endpoint=clientFromString(Mock(), "tcp:localhost:9050"),
+            reactor=reactor,
+        )
+        d = endpoint._get_address()
+        self.assertTrue(not d.called)

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -640,14 +640,10 @@ class SocksConnectTests(unittest.TestCase):
         factory = Mock()
         factory.buildProtocol = Mock(return_value=protocol)
         ep = socks.TorSocksEndpoint(socks_ep, u'meejah.ca', 443, tls=True)
-        # calling it before there's a factory
-        with self.assertRaises(RuntimeError) as ctx:
-            yield ep._get_address()
         yield ep.connect(factory)
         addr = yield ep._get_address()
 
         self.assertEqual(addr, IPv4Address('TCP', '10.0.0.1', 12345))
-        self.assertTrue('call .connect()' in str(ctx.exception))
         self.assertEqual(2, len(delayed_addr))
         self.assertTrue(delayed_addr[0] is not delayed_addr[1])
         self.assertTrue(all([d.called for d in delayed_addr]))

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -229,7 +229,7 @@ class SocksStateMachine(unittest.TestCase):
         # should be relaying now, try sending some datas
 
         client_proto.transport.write(b'abcdef')
-        addr = yield factory.get_address()
+        addr = yield factory._get_address()
 
         # FIXME how shall we test for IPv6-ness?
         assert addr is expected_address
@@ -626,8 +626,8 @@ class SocksConnectTests(unittest.TestCase):
         delayed_addr = []
 
         def connect(factory):
-            delayed_addr.append(factory.get_address())
-            delayed_addr.append(factory.get_address())
+            delayed_addr.append(factory._get_address())
+            delayed_addr.append(factory._get_address())
             factory.startFactory()
             proto = factory.buildProtocol("addr")
             proto.makeConnection(transport)
@@ -642,9 +642,9 @@ class SocksConnectTests(unittest.TestCase):
         ep = socks.TorSocksEndpoint(socks_ep, u'meejah.ca', 443, tls=True)
         # calling it before there's a factory
         with self.assertRaises(RuntimeError) as ctx:
-            yield ep.get_address()
+            yield ep._get_address()
         yield ep.connect(factory)
-        addr = yield ep.get_address()
+        addr = yield ep._get_address()
 
         self.assertEqual(addr, IPv4Address('TCP', '10.0.0.1', 12345))
         self.assertTrue('call .connect()' in str(ctx.exception))
@@ -654,11 +654,11 @@ class SocksConnectTests(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_address(self):
-        # normally, .get_address is only called via the
+        # normally, ._get_address is only called via the
         # attach_stream() method on Circuit
         addr = object()
         factory = socks._TorSocksFactory()
-        d = factory.get_address()
+        d = factory._get_address()
         self.assertFalse(d.called)
         factory._did_connect(addr)
 
@@ -667,7 +667,7 @@ class SocksConnectTests(unittest.TestCase):
         self.assertEqual(addr, maybe_addr)
 
         # if we do it a second time, should be immediate
-        d = factory.get_address()
+        d = factory._get_address()
         self.assertTrue(d.called)
         self.assertEqual(d.result, addr)
 

--- a/test/test_torstate.py
+++ b/test/test_torstate.py
@@ -519,6 +519,24 @@ class StateTests(unittest.TestCase):
             b' __LeaveStreamsUnattached=0\r\n'
         )
 
+    def test_attacher_twice(self):
+        """
+        It should be an error to set an attacher twice
+        """
+        @implementer(IStreamAttacher)
+        class MyAttacher(object):
+            pass
+
+        attacher = MyAttacher()
+        self.state.set_attacher(attacher, FakeReactor(self))
+        # attach the *same* instance twice; not an error
+        self.state.set_attacher(attacher, FakeReactor(self))
+        with self.assertRaises(RuntimeError) as ctx:
+            self.state.set_attacher(MyAttacher(), FakeReactor(self))
+        self.assertTrue(
+            "already have an attacher" in str(ctx.exception)
+        )
+
     def test_attacher(self):
         @implementer(IStreamAttacher)
         class MyAttacher(object):

--- a/txtorcon/attacher.py
+++ b/txtorcon/attacher.py
@@ -16,7 +16,9 @@ class PriorityAttacher(object):
     """
     This can fill the role of an IStreamAttacher to which you can add
     and remove "sub" attachers. These are consulted in order and the
-    first one to return something besides None or DO_NOT_ATTACH wins.
+    first one to return something besides None wins. We use a "heapq"
+    priority queue, with 0 being the "most important" and higher
+    numbers indicating less important.
 
     For example::
 

--- a/txtorcon/attacher.py
+++ b/txtorcon/attacher.py
@@ -1,0 +1,80 @@
+import itertools
+import heapq
+
+from zope.interface import implementer
+
+from .interface import IStreamAttacher
+
+
+# note to self: might be better to make this Way Simpler and just say
+# "order matters", *or* do a simple sort -- so that we can actually
+# remove things.
+
+
+@implementer(IStreamAttacher)
+class PriorityAttacher(object):
+    """
+    This can fill the role of an IStreamAttacher to which you can add
+    and remove "sub" attachers. These are consulted in order and the
+    first one to return something besides None or DO_NOT_ATTACH wins.
+
+    For example::
+
+        tor = yield txtorcon.connect(..)
+        attachers = txtorcon.attacher.PriorityAttacher()
+
+        @implementer(IStreamAttacher)
+        class MyAttacher(object):
+            def __init__(self, interesting_host, circuit):
+                self._host = interesting_host
+                self._circuit = circuit
+
+            def attach_stream(self, stream, circuits):
+                if stream.target_host == self._host:
+                    return self._circuit
+                return None
+
+        attachers.add_attacher(MyAttacher('torproject.org', circ1))
+        attachers.add_attacher(MyAttacher('meejah.ca', circ2))
+    """
+
+    def __init__(self):
+        # use only heapq.* to modify this; 0th item is "smallest"
+        # item. contains 3-tuples of (priority, number, attacher)
+        self._attacher_heap = []
+        # need to keep a map so we can delete from the priority-queue :(
+        self._attacher_to_entry = dict()
+        # need to keep a counter so the sorting has a tie-breaker
+        self._counter = itertools.count(0, 1)
+
+    def add_attacher(self, attacher, priority=0):
+        """
+        Add a new IStreamAttacher at a certain priortiy; lower priority
+        values mean more important (that is, 0 is the most important).
+        """
+        item = [priority, next(self._counter), IStreamAttacher(attacher)]
+        self._attacher_to_entry[attacher] = item
+        heapq.heappush(self._attacher_heap, item)
+
+    def remove_attacher(self, attacher):
+        try:
+            item = self._attacher_to_entry.pop(attacher)
+        except KeyError:
+            raise ValueError(
+                "attacher {} not found".format(attacher)
+            )
+        item[-1] = None  # we can't actually remove it from the heap ...
+
+    def attach_stream_failure(self, stream, fail):
+        pass
+    # hmm, should we try to remember which attacher answered
+    # 'something' for this stream, and then report the failure via
+    # it...? or just log all failures here?
+
+    def attach_stream(self, stream, circuits):
+        for _, _, attacher in self._attacher_heap:
+            if attacher is not None:
+                answer = attacher.attach_stream(stream, circuits)
+                if answer is not None:
+                    return answer
+        return None

--- a/txtorcon/circuit.py
+++ b/txtorcon/circuit.py
@@ -90,6 +90,7 @@ class _CircuitAttacher(object):
                         circuit=circuit,
                     )
                 )))
+                return
             d.callback(None)
             defer.returnValue(circuit)
         except Exception:
@@ -102,6 +103,8 @@ def _get_circuit_attacher(reactor, state):
         _get_circuit_attacher.attacher = _CircuitAttacher()
         yield state.set_attacher(_get_circuit_attacher.attacher, reactor)
     defer.returnValue(_get_circuit_attacher.attacher)
+
+
 _get_circuit_attacher.attacher = None
 
 

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -391,10 +391,7 @@ class TCPHiddenServiceEndpoint(object):
         # self.config is always a Deferred; see __init__
         self.config = yield self.config
         # just to be sure:
-        # yield self.config.post_bootstrap
-        # XXX ^-- something fishy with that -- in tests, even when
-        # post_bootstrap is definitely already called, the above hangs
-        # (but e.g. "yield defer.succeed(None)" does not...
+        yield self.config.post_bootstrap
 
         # XXX - perhaps allow the user to pass in an endpoint
         # descriptor and make this one the default? Then would

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -33,7 +33,6 @@ from zope.interface import implementer
 from zope.interface import Interface, Attribute
 
 from .torconfig import TorConfig, launch_tor, HiddenService
-from .torstate import build_tor_connection
 
 
 _global_tor = None  # instance of txtorcon.controller.Tor
@@ -406,7 +405,7 @@ class TCPHiddenServiceEndpoint(object):
         # self.config is always a Deferred; see __init__
         self.config = yield self.config
         # just to be sure:
-        ##yield self.config.post_bootstrap
+        # yield self.config.post_bootstrap
         # XXX ^-- something fishy with that -- in tests, even when
         # post_bootstrap is definitely already called, the above hangs
         # (but e.g. "yield defer.succeed(None)" does not...
@@ -721,7 +720,6 @@ class TorClientEndpoint(object):
     @defer.inlineCallbacks
     def connect(self, protocolfactory):
         last_error = None
-        kwargs = dict()
         # XXX fix in socks.py stuff for socks_username, socks_password
         if self._socks_username or self._socks_password:
             raise RuntimeError(

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -731,7 +731,7 @@ class TorClientEndpoint(object):
                 self._tls,
             )
             # forward the address to any listeners we have
-            socks_ep._get_address().addBoth(self._when_address.fire)
+            socks_ep._get_address().addCallback(self._when_address.fire)
             proto = yield socks_ep.connect(protocolfactory)
             defer.returnValue(proto)
         else:
@@ -743,7 +743,7 @@ class TorClientEndpoint(object):
                 )
                 socks_ep = TorSocksEndpoint(tor_ep, self.host, self.port, self._tls)
                 # forward the address to any listeners we have
-                socks_ep._get_address().addBoth(self._when_address.fire)
+                socks_ep._get_address().addCallback(self._when_address.fire)
                 try:
                     proto = yield socks_ep.connect(protocolfactory)
                     defer.returnValue(proto)

--- a/txtorcon/interface.py
+++ b/txtorcon/interface.py
@@ -97,6 +97,17 @@ class IStreamAttacher(Interface):
     :class:`txtorcon.Circuit` it should be attached to.
     """
 
+    def attach_stream_failure(stream, fail):
+        """
+        :param stream:
+            The stream we were trying to attach.
+
+        :param fail:
+            A Failure instance.
+
+        A failure has occurred while trying to attach the stream.
+        """
+
     def attach_stream(stream, circuits):
         """
         :param stream:

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -552,26 +552,19 @@ class _TorSocksFactory(Factory):
     def __init__(self, *args, **kw):
         self._args = args
         self._kw = kw
-        self._connected_d = []
         self._host = None
+        self._when_connected = util.SingleObserver()
 
     def _get_address(self):
         """
         Returns a Deferred that fires with the transport's getHost()
         when this SOCKS protocol becomes connected.
         """
-        d = Deferred()
-        if self._host:
-            d.callback(self._host)
-        else:
-            self._connected_d.append(d)
-        return d
+        return self._when_connected.when_fired()
 
     def _did_connect(self, host):
         self._host = host
-        for d in self._connected_d:
-            d.callback(host)
-        self._connected_d = None
+        self._when_connected.fire(host)
 
     def buildProtocol(self, addr):
         p = self.protocol(*self._args, **self._kw)

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -460,6 +460,12 @@ class _SocksMachine(object):
         enter=abort,
         outputs=[_disconnect],
     )
+# XXX FIXME this needs a test
+    sent_request.upon(
+        disconnected,
+        enter=abort,
+        outputs=[_disconnect],  # ... or is this redundant?
+    )
 
     relaying.upon(
         got_data,

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -665,6 +665,7 @@ class TorSocksEndpoint(object):
             )
 
         self._socks_factory = socks_factory
+        # XXX isn't this just maybeDeferred()
         if isinstance(self._proxy_ep, Deferred):
             proxy_ep = yield self._proxy_ep
         else:

--- a/txtorcon/torstate.py
+++ b/txtorcon/torstate.py
@@ -275,7 +275,7 @@ class TorState(object):
         self.authorities = {}
 
         #: see set_attacher
-        self.cleanup = None
+        self._cleanup = None
 
         class die(object):
             __name__ = 'die'  # FIXME? just to ease spagetti.py:82's pain
@@ -484,14 +484,16 @@ class TorState(object):
 
         if self.attacher is None:
             d = self.undo_attacher()
-            if self.cleanup:
-                react.removeSystemEventTrigger(self.cleanup)
-                self.cleanup = None
+            if self._cleanup:
+                react.removeSystemEventTrigger(self._cleanup)
+                self._cleanup = None
 
         else:
             d = self.protocol.set_conf("__LeaveStreamsUnattached", "1")
-            self.cleanup = react.addSystemEventTrigger('before', 'shutdown',
-                                                       self.undo_attacher)
+            self._cleanup = react.addSystemEventTrigger(
+                'before', 'shutdown',
+                self.undo_attacher,
+            )
         return d
 
     # noqa

--- a/txtorcon/torstate.py
+++ b/txtorcon/torstate.py
@@ -485,6 +485,12 @@ class TorState(object):
 
         react = IReactorCore(myreactor)
         if attacher:
+            if self._attacher is attacher:
+                return
+            if self._attacher is not None:
+                raise RuntimeError(
+                    "set_attacher called but we already have an attacher"
+                )
             self._attacher = IStreamAttacher(attacher)
         else:
             self._attacher = None

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -462,3 +462,4 @@ class SingleObserver(object):
         for d in self._observers:
             d.callback(self._fired)
         self._observers = None
+        return value  # so we're transparent if used as a callback


### PR DESCRIPTION
Merge the new "put a stream on a specific circuit" APIs from `release-1.x` which basically side-steps the `set_attacher` stuff.

New code (that's not on release-1.x) and is required:

- [x] "soft-deprecate" / discourage (public) use of set_attacher API
- [x] make it an error to use both APIs at once
- [x] add "PriorityAttacher" or similar, so you get an add/remote attacher API without changing "the" API

After the doc changes are merged, they should be upgraded to discuss all the issues with attachment (that is that Tor doesn't deal properly with > 1 controller being an attacher).