### PR TITLE
Import `Twisted[tls]` and `automat`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 ## see also dev-requirements.txt to build
 ## hmm, travis-ci doesn't like this since we need a GeoIP-dev package
 ##GeoIP>=1.2.9
-Twisted>=11.1.0
+Twisted[tls]>=11.1.0
 ipaddress>=1.0.16
 zope.interface>=3.6.1
 incremental
+automat


### PR DESCRIPTION
Hello @meejah! Today I tried to install a newer version of txtorcon (from the cloned repo with `pip install -e`) and I had the following issue:

```
    File "test.py", line 3, in <module>
        import txtorcon  
    File "/home/user/Desktop/txtorcon/txtorcon/__init__.py", line 16, in <module>
        from txtorcon.controller import connect
    File "/home/user/Desktop/txtorcon/txtorcon/controller.py", line 33, in <module>
        from txtorcon.endpoints import TorClientEndpoint
    File "/home/user/Desktop/txtorcon/txtorcon/endpoints.py", line 14, in <module>
        from txtorcon.socks import TorSocksEndpoint
    File "/home/user/Desktop/txtorcon/txtorcon/socks.py", line 18, in <module>
        from twisted.protocols import tls
    File "/home/user/Desktop/env/local/lib/python2.7/site-packages/twisted/protocols/tls.py", line 41, in <module>
        from OpenSSL.SSL import Error, ZeroReturnError, WantReadError
ImportError: No module named OpenSSL.SSL
```

```
    File "test.py", line 3, in <module>
        import txtorcon  
    File "/home/user/Desktop/txtorcon/txtorcon/__init__.py", line 16, in <module>
        from txtorcon.controller import connect
    File "/home/user/Desktop/txtorcon/txtorcon/controller.py", line 33, in <module>
        from txtorcon.endpoints import TorClientEndpoint
    File "/home/user/Desktop/txtorcon/txtorcon/endpoints.py", line 14, in <module>
        from txtorcon.socks import TorSocksEndpoint
    File "/home/user/Desktop/txtorcon/txtorcon/socks.py", line 22, in <module>
        import automat
ImportError: No module named automat
```

I took a look at the requirements from `release-1.x`: `Twisted[tls]` and `automat` are used. I updated `requirements.txt` and it worked. Maybe the file from `1.x` should've been merged as well?

Thanks!