### PR TITLE
Create separate classes for each SOCKS error

### DIFF
--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -299,7 +299,7 @@ class SocksStateMachine(unittest.TestCase):
         sm.feed_data(b'\x05\x05\x00\x01\x00\x00\x00\x00\xff\xff')
 
         self.assertEqual(1, len(dis))
-        self.assertEqual("Connection refused", dis[0])
+        self.assertEqual(socks.ConnectionRefusedError.message, dis[0])
 
     def test_end_to_end_successful_relay(self):
 
@@ -573,7 +573,8 @@ class SocksConnectTests(unittest.TestCase):
         ep = socks.TorSocksEndpoint(socks_ep, u'meejah.ca', 443, tls=True)
         with self.assertRaises(Exception) as ctx:
             yield ep.connect(factory)
-        self.assertTrue('general SOCKS server failure' in str(ctx.exception))
+        self.assertTrue(isinstance(ctx.exception,
+                                   socks.GeneralServerFailureError))
 
     @defer.inlineCallbacks
     def test_connect_socks_error_unknown(self):
@@ -617,7 +618,8 @@ class SocksConnectTests(unittest.TestCase):
         ep = socks.TorSocksEndpoint(socks_ep, u'meejah.ca', 443, tls=True)
         with self.assertRaises(Exception) as ctx:
             yield ep.connect(factory)
-        self.assertTrue('general SOCKS server failure' in str(ctx.exception))
+        self.assertTrue(isinstance(ctx.exception,
+                                   socks.GeneralServerFailureError))
 
     @defer.inlineCallbacks
     def test_get_address_endpoint(self):

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -149,7 +149,7 @@ class SocksStateMachine(unittest.TestCase):
         )
         with self.assertRaises(Exception) as ctx:
             yield d
-        self.assertIn('Unknown SOCKS reply code', str(ctx.exception))
+        self.assertIn('Unknown SOCKS error-code', str(ctx.exception))
 
     @defer.inlineCallbacks
     def test_socks_relay_data(self):
@@ -595,7 +595,7 @@ class SocksConnectTests(unittest.TestCase):
         ep = socks.TorSocksEndpoint(socks_ep, u'meejah.ca', 443, tls=True)
         with self.assertRaises(Exception) as ctx:
             yield ep.connect(factory)
-        self.assertTrue('Unknown SOCKS reply code' in str(ctx.exception))
+        self.assertTrue('Unknown SOCKS error-code' in str(ctx.exception))
 
     @defer.inlineCallbacks
     def test_connect_socks_illegal_byte(self):

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -736,6 +736,7 @@ class SocksErrorTests(unittest.TestCase):
         self.assertTrue(isinstance(error, cls_))
         self.assertEquals(error.code, code)
         self.assertEquals(error.message, message)
+        self.assertEquals(str(error), message)
 
     def test_socks_error_factory(self):
         for cls in socks.SocksError.__subclasses__():

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -738,7 +738,7 @@ class SocksErrorTests(unittest.TestCase):
         self.assertEquals(error.message, message)
         self.assertEquals(str(error), message)
 
-    def test_socks_error_factory(self):
+    def test_error_factory(self):
         for cls in socks.SocksError.__subclasses__():
             error = socks._create_socks_error(cls.code)
             self._check_error(error, cls, cls.code, cls.message)

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -751,7 +751,7 @@ class SocksErrorTests(unittest.TestCase):
         self._check_error(socks.SocksError(message=message),
                           socks.SocksError, None, message)
         self._check_error(socks.SocksError(code=code),
-                          socks.SocksError, code, None)
+                          socks.SocksError, code, '')
         self._check_error(socks.SocksError(message, code=code),
                           socks.SocksError, code, message)
         self._check_error(socks.SocksError(message=message, code=code),

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -743,6 +743,7 @@ class SocksErrorTests(unittest.TestCase):
         def check(e, c, m):
             self.assertEquals(e.code, c)
             self.assertEquals(e.message, m)
+            self.assertTrue(isinstance(e, socks.SocksError))
 
         code = 0xFF
         message = 'Custom error message'

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -729,3 +729,26 @@ class SocksResolveTests(unittest.TestCase):
             isinstance(fac.mock_calls[0][1][0], text_type)
         )
         return d
+
+
+class SocksErrorTests(unittest.TestCase):
+    def test_socks_error_factory(self):
+        for cls in socks.SocksError.__subclasses__():
+            error = socks._create_socks_error(cls.code)
+            self.assertEquals(error.code, cls.code)
+            self.assertEquals(error.message, cls.message)
+            self.assertTrue(isinstance(error, cls))
+
+    def test_custom_error(self):
+        def check(e, c, m):
+            self.assertEquals(e.code, c)
+            self.assertEquals(e.message, m)
+
+        code = 0xFF
+        message = 'Custom error message'
+
+        check(socks.SocksError(message), None, message)
+        check(socks.SocksError(message=message), None, message)
+        check(socks.SocksError(code=code), code, None)
+        check(socks.SocksError(message, code=code), code, message)
+        check(socks.SocksError(message=message, code=code), code, message)

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -336,7 +336,7 @@ class SocksStateMachine(unittest.TestCase):
         # should *not* have disconnected
         self.assertEqual(0, len(dis))
         self.assertTrue(the_proto.data, b"this is some relayed data")
-        sm.disconnected("it's fine")
+        sm.disconnected(socks.SocksError("it's fine"))
         self.assertEqual(1, len(Proto.lost))
         self.assertTrue("it's fine" in str(Proto.lost[0]))
 

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -732,24 +732,27 @@ class SocksResolveTests(unittest.TestCase):
 
 
 class SocksErrorTests(unittest.TestCase):
+    def _check_error(self, error, cls_, code, message):
+        self.assertTrue(isinstance(error, cls_))
+        self.assertEquals(error.code, code)
+        self.assertEquals(error.message, message)
+
     def test_socks_error_factory(self):
         for cls in socks.SocksError.__subclasses__():
             error = socks._create_socks_error(cls.code)
-            self.assertEquals(error.code, cls.code)
-            self.assertEquals(error.message, cls.message)
-            self.assertTrue(isinstance(error, cls))
+            self._check_error(error, cls, cls.code, cls.message)
 
     def test_custom_error(self):
-        def check(e, c, m):
-            self.assertEquals(e.code, c)
-            self.assertEquals(e.message, m)
-            self.assertTrue(isinstance(e, socks.SocksError))
-
         code = 0xFF
         message = 'Custom error message'
 
-        check(socks.SocksError(message), None, message)
-        check(socks.SocksError(message=message), None, message)
-        check(socks.SocksError(code=code), code, None)
-        check(socks.SocksError(message, code=code), code, message)
-        check(socks.SocksError(message=message, code=code), code, message)
+        self._check_error(socks.SocksError(message),
+                          socks.SocksError, None, message)
+        self._check_error(socks.SocksError(message=message),
+                          socks.SocksError, None, message)
+        self._check_error(socks.SocksError(code=code),
+                          socks.SocksError, code, None)
+        self._check_error(socks.SocksError(message, code=code),
+                          socks.SocksError, code, message)
+        self._check_error(socks.SocksError(message=message, code=code),
+                          socks.SocksError, code, message)

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -28,7 +28,6 @@ __all__ = (
     'resolve',
     'resolve_ptr',
     'SocksError',
-    'SucceededReply',
     'GeneralServerFailureError',
     'ConnectionNotAllowedError',
     'NetworkUnreachableError',
@@ -581,11 +580,6 @@ class SocksError(Exception):
     def __init__(self, message=None, code=None):
         super(SocksError, self).__init__(message or self.message)
         self.code = code or self.code
-
-
-class SucceededReply(SocksError):
-    code = 0x00
-    message = 'succeeded'
 
 
 class GeneralServerFailureError(SocksError):

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -576,9 +576,11 @@ class _TorSocksFactory(Factory):
 
 class SocksError(Exception):
     code = None
+    message = None
 
     def __init__(self, message=None, code=None):
         super(SocksError, self).__init__(message or self.message)
+        self.message = message or self.message
         self.code = code or self.code
 
 

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -628,7 +628,7 @@ class AddressTypeNotSupportedError(SocksError):
     message = 'Address type not supported'
 
 
-_socks_errors = {cls().code: cls for cls in SocksError.__subclasses__()}
+_socks_errors = {cls.code: cls for cls in SocksError.__subclasses__()}
 
 
 def _create_socks_error(code):

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -576,9 +576,9 @@ class _TorSocksFactory(Factory):
 
 class SocksError(Exception):
     code = None
-    message = None
+    message = ''
 
-    def __init__(self, message=None, code=None):
+    def __init__(self, message='', code=None):
         super(SocksError, self).__init__(message or self.message)
         self.message = message or self.message
         self.code = code or self.code

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -629,7 +629,7 @@ def _create_socks_error(code):
     try:
         return _socks_errors[code]()
     except KeyError:
-        return SocksError("Unknown SOCKS reply code {}".format(code),
+        return SocksError("Unknown SOCKS error-code {}".format(code),
                           code=code)
 
 

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -37,7 +37,6 @@ __all__ = (
     'TtlExpiredError',
     'CommandNotSupportedError',
     'AddressTypeNotSupportedError',
-    'SocksErrorFactory',
     'TorSocksEndpoint',
 )
 
@@ -200,7 +199,7 @@ class _SocksMachine(object):
             return
 
         if reply != self.SUCCEEDED:
-            if reply in SocksErrorFactory.socks_errors:
+            if reply in _socks_errors:
                 self.reply_error(reply)
             else:
                 self.reply_error("Unknown SOCKS reply code {}".format(reply))
@@ -289,7 +288,7 @@ class _SocksMachine(object):
     def _disconnect(self, error_message):
         "done"
         try:
-            error = SocksErrorFactory.create(error_message)
+            error = _create_socks_error(error_message)
         except KeyError:
             error = SocksError(error_message)
 
@@ -633,12 +632,11 @@ class AddressTypeNotSupportedError(SocksError):
     message = 'Address type not supported'
 
 
-class SocksErrorFactory(object):
-    socks_errors = {cls().code: cls for cls in SocksError.__subclasses__()}
+_socks_errors = {cls().code: cls for cls in SocksError.__subclasses__()}
 
-    @classmethod
-    def create(cls, code):
-        return cls.socks_errors[code]()
+
+def _create_socks_error(code):
+    return _socks_errors[code]()
 
 
 @inlineCallbacks

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -288,7 +288,7 @@ class _SocksMachine(object):
     def _disconnect(self, error):
         "done"
         if self._on_disconnect:
-            self._on_disconnect(error.message)
+            self._on_disconnect(str(error))
         if self._sender:
             self._sender.connectionLost(Failure(error))
         self._when_done.fire(Failure(error))

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -582,9 +582,9 @@ class _TorSocksFactory(Factory):
 
 class SocksError(Exception):
 
-    def __init__(self, message, errno=None):
+    def __init__(self, message, code=None):
         super(SocksError, self).__init__(message)
-        self.errno = errno
+        self.code = code
 
 
 class SucceededReply(SocksError):
@@ -592,7 +592,7 @@ class SucceededReply(SocksError):
     def __init__(self):
         super(SucceededReply, self).__init__(
             message='succeeded',
-            errno=0x00)
+            code=0x00)
 
 
 class GeneralServerFailureError(SocksError):
@@ -600,7 +600,7 @@ class GeneralServerFailureError(SocksError):
     def __init__(self):
         super(GeneralServerFailureError, self).__init__(
             message='general SOCKS server failure',
-            errno=0x01)
+            code=0x01)
 
 
 class ConnectionNotAllowedError(SocksError):
@@ -608,7 +608,7 @@ class ConnectionNotAllowedError(SocksError):
     def __init__(self):
         super(ConnectionNotAllowedError, self).__init__(
             message='connection not allowed by ruleset',
-            errno=0x02)
+            code=0x02)
 
 
 class NetworkUnreachableError(SocksError):
@@ -616,7 +616,7 @@ class NetworkUnreachableError(SocksError):
     def __init__(self):
         super(NetworkUnreachableError, self).__init__(
             message='Network unreachable',
-            errno=0x03)
+            code=0x03)
 
 
 class HostUnreachableError(SocksError):
@@ -624,7 +624,7 @@ class HostUnreachableError(SocksError):
     def __init__(self):
         super(HostUnreachableError, self).__init__(
             message='Host unreachable',
-            errno=0x04)
+            code=0x04)
 
 
 class ConnectionRefusedError(SocksError):
@@ -632,7 +632,7 @@ class ConnectionRefusedError(SocksError):
     def __init__(self):
         super(ConnectionRefusedError, self).__init__(
             message='Connection refused',
-            errno=0x05)
+            code=0x05)
 
 
 class TtlExpiredError(SocksError):
@@ -640,7 +640,7 @@ class TtlExpiredError(SocksError):
     def __init__(self):
         super(TtlExpiredError, self).__init__(
             message='TTL expired',
-            errno=0x06)
+            code=0x06)
 
 
 class CommandNotSupportedError(SocksError):
@@ -648,7 +648,7 @@ class CommandNotSupportedError(SocksError):
     def __init__(self):
         super(CommandNotSupportedError, self).__init__(
             message='Command not supported',
-            errno=0x07)
+            code=0x07)
 
 
 class AddressTypeNotSupportedError(SocksError):
@@ -656,15 +656,15 @@ class AddressTypeNotSupportedError(SocksError):
     def __init__(self):
         super(AddressTypeNotSupportedError, self).__init__(
             message='Address type not supported',
-            errno=0x08)
+            code=0x08)
 
 
 class SocksErrorFactory(object):
-    socks_errors = {cls().errno: cls for cls in SocksError.__subclasses__()}
+    socks_errors = {cls().code: cls for cls in SocksError.__subclasses__()}
 
     @classmethod
-    def create(cls, errno):
-        return cls.socks_errors[errno]()
+    def create(cls, code):
+        return cls.socks_errors[code]()
 
 
 @inlineCallbacks

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -581,82 +581,56 @@ class _TorSocksFactory(Factory):
 
 
 class SocksError(Exception):
+    code = None
 
-    def __init__(self, message, code=None):
-        super(SocksError, self).__init__(message)
-        self.code = code
+    def __init__(self, message=None, code=None):
+        super(SocksError, self).__init__(message or self.message)
+        self.code = code or self.code
 
 
 class SucceededReply(SocksError):
-
-    def __init__(self):
-        super(SucceededReply, self).__init__(
-            message='succeeded',
-            code=0x00)
+    code = 0x00
+    message = 'succeeded'
 
 
 class GeneralServerFailureError(SocksError):
-
-    def __init__(self):
-        super(GeneralServerFailureError, self).__init__(
-            message='general SOCKS server failure',
-            code=0x01)
+    code = 0x01
+    message = 'general SOCKS server failure'
 
 
 class ConnectionNotAllowedError(SocksError):
-
-    def __init__(self):
-        super(ConnectionNotAllowedError, self).__init__(
-            message='connection not allowed by ruleset',
-            code=0x02)
+    code = 0x02
+    message = 'connection not allowed by ruleset'
 
 
 class NetworkUnreachableError(SocksError):
-
-    def __init__(self):
-        super(NetworkUnreachableError, self).__init__(
-            message='Network unreachable',
-            code=0x03)
+    code = 0x03
+    message = 'Network unreachable'
 
 
 class HostUnreachableError(SocksError):
-
-    def __init__(self):
-        super(HostUnreachableError, self).__init__(
-            message='Host unreachable',
-            code=0x04)
+    code = 0x04
+    message = 'Host unreachable'
 
 
 class ConnectionRefusedError(SocksError):
-
-    def __init__(self):
-        super(ConnectionRefusedError, self).__init__(
-            message='Connection refused',
-            code=0x05)
+    code = 0x05
+    message = 'Connection refused'
 
 
 class TtlExpiredError(SocksError):
-
-    def __init__(self):
-        super(TtlExpiredError, self).__init__(
-            message='TTL expired',
-            code=0x06)
+    code = 0x06
+    message = 'TTL expired'
 
 
 class CommandNotSupportedError(SocksError):
-
-    def __init__(self):
-        super(CommandNotSupportedError, self).__init__(
-            message='Command not supported',
-            code=0x07)
+    code = 0x07
+    message = 'Command not supported'
 
 
 class AddressTypeNotSupportedError(SocksError):
-
-    def __init__(self):
-        super(AddressTypeNotSupportedError, self).__init__(
-            message='Address type not supported',
-            code=0x08)
+    code = 0x08
+    message = 'Address type not supported'
 
 
 class SocksErrorFactory(object):


### PR DESCRIPTION
These changes intend to make the improvement proposed in #214.

I made a very simple factory, inspired by the strings dictionary. What do you think?

I'd also like to know your opinion on the class names (specially `SucceededReply`).

I tried not to change things too much, so `_disconnect`  now expects `error_message` to be either a message or a code (would the name of the arg have to change?). If the code is found, it will instantiate the proper error. Otherwise it will be a `SocksError` with the message. That implies that if `error_message` is a code, there must exist a corresponding error because then the `SocksError` message will be just the code. Should it always be cast to `str`?

Do you think the factory should always create an error or just when it can actually create the specific classes? I think it should fail to create when the code is unknown, as it is currently.

If that seems a bit strange, maybe `_disconnect` should expect a `SocksError` instead of a message and the object should be created before the calls by each method.

Let me know if you would like that I followed some pattern/convention/etc.

Thanks!