### PR TITLE
Accept `Dependent` for Tor >= 0.3.0.2-alpha

### DIFF
--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1104,7 +1104,7 @@ class TorConfig(object):
                 self._setup_hidden_services(servicelines)
                 continue
 
-            if value == 'Dependant':
+            if value == 'Dependant' or value == 'Dependent':
                 continue
 
             # there's a thing called "Boolean+Auto" which is -1 for


### PR DESCRIPTION
As I was reading the specs recently, I noticed the following note and thought it wouldn't hurt to add this other conditional.

> Note: The incorrect spelling "Dependant" was used from the time
> this key was introduced in Tor 0.1.1.4-alpha until it was corrected
> in Tor 0.3.0.2-alpha.  It is recommended that clients accept both
> spellings.

Could this be useful?