### PR TITLE
Docs for SOCKS5 errors

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -393,8 +393,9 @@ methods are un-suitable (as those are the suggested API).
 
 You should expect these APIs to raise SOCKS5 errors, which can all be
 handled by catching the :class:`txtorcon.socks.SocksError` class. If
-you need to work with each specific error, see the ":ref:`socks`" for
-a list of them.
+you need to work with each specific error (corresponding to the
+`RFC-specified SOCKS5 replies`_), see the ":ref:`socks`" for a list of
+them.
 
 .. _guide_onions:
 
@@ -751,3 +752,4 @@ XXX what about a "config object" idea, e.g. could have keys:
 .. _serverfromstring: http://twistedmatrix.com/documents/current/api/twisted.internet.endpoints.html#serverFromString
 .. _ilisteningport: http://twistedmatrix.com/documents/current/api/twisted.internet.interfaces.IListeningPort.html
 .. _treq: https://github.com/twisted/treq
+.. _`rfc-specified socks5 replies`: https://tools.ietf.org/html/rfc1928#section-6

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -391,6 +391,10 @@ There are also lower-level APIs to create
 using this API, I'd be curious to learn why the :class:`txtorcon.Tor`
 methods are un-suitable (as those are the suggested API).
 
+You should expect these APIs to raise SOCKS5 errors, which can all be
+handled by catching the :class:`txtorcon.socks.SocksError` class. If
+you need to work with each specific error, see the ":ref:`socks`" for
+a list of them.
 
 .. _guide_onions:
 

--- a/docs/txtorcon-socks.rst
+++ b/docs/txtorcon-socks.rst
@@ -49,3 +49,26 @@ CommandNotSupportedError
 AddressTypeNotSupportedError
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: txtorcon.socks.AddressTypeNotSupportedError
+
+
+Low-level
+---------
+The following sections present low-level APIs which might change
+anytime and break your program. If you are able to work with the
+high-level APIs that use these, you should do so. Otherwise, go ahead
+as you know what you are doing.
+
+
+resolve
+~~~~~~~
+.. autofunction:: txtorcon.socks.resolve
+
+
+resolve_ptr
+~~~~~~~~~~~
+.. autofunction:: txtorcon.socks.resolve_ptr
+
+
+TorSocksEndpoint
+~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.TorSocksEndpoint

--- a/docs/txtorcon-socks.rst
+++ b/docs/txtorcon-socks.rst
@@ -1,0 +1,51 @@
+.. _socks:
+
+:mod:`txtorcon.socks` Module
+============================
+
+SOCKS5 Errors
+-------------
+
+SocksError
+~~~~~~~~~~
+.. autoclass:: txtorcon.socks.SocksError
+
+
+GeneralServerFailureError
+~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.GeneralServerFailureError
+
+
+ConnectionNotAllowedError
+~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.ConnectionNotAllowedError
+
+
+NetworkUnreachableError
+~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.NetworkUnreachableError
+
+
+HostUnreachableError
+~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.HostUnreachableError
+
+
+ConnectionRefusedError
+~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.ConnectionRefusedError
+
+
+TtlExpiredError
+~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.TtlExpiredError
+
+
+CommandNotSupportedError
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.CommandNotSupportedError
+
+
+AddressTypeNotSupportedError
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: txtorcon.socks.AddressTypeNotSupportedError

--- a/docs/txtorcon-socks.rst
+++ b/docs/txtorcon-socks.rst
@@ -51,24 +51,23 @@ AddressTypeNotSupportedError
 .. autoclass:: txtorcon.socks.AddressTypeNotSupportedError
 
 
-Low-level
----------
-The following sections present low-level APIs which might change
-anytime and break your program. If you are able to work with the
-high-level APIs that use these, you should do so. Otherwise, go ahead
-as you know what you are doing.
+.. note::
+    The following sections present low-level APIs which might change
+    anytime and break your program. If you are able to work with the
+    high-level APIs that use these, you should do so. Otherwise, go
+    ahead as you know what you are doing.
 
 
 resolve
-~~~~~~~
+-------
 .. autofunction:: txtorcon.socks.resolve
 
 
 resolve_ptr
-~~~~~~~~~~~
+-----------
 .. autofunction:: txtorcon.socks.resolve_ptr
 
 
 TorSocksEndpoint
-~~~~~~~~~~~~~~~~
+----------------
 .. autoclass:: txtorcon.socks.TorSocksEndpoint

--- a/docs/txtorcon-socks.rst
+++ b/docs/txtorcon-socks.rst
@@ -52,10 +52,9 @@ AddressTypeNotSupportedError
 
 
 .. note::
-    The following sections present low-level APIs which might change
-    anytime and break your program. If you are able to work with the
-    high-level APIs that use these, you should do so. Otherwise, go
-    ahead as you know what you are doing.
+    The following sections present low-level APIs. If you are able
+    to work with :class:`txtorcon.Tor`'s corresponding high-level
+    APIs, you should do so.
 
 
 resolve

--- a/docs/txtorcon.rst
+++ b/docs/txtorcon.rst
@@ -15,5 +15,6 @@ place to start**.
     txtorcon-config
     txtorcon-endpoints
     txtorcon-protocol
+    txtorcon-socks
     txtorcon-interface
     txtorcon-util

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -655,18 +655,18 @@ def resolve(tor_endpoint, hostname):
 
 
 @inlineCallbacks
-def resolve_ptr(tor_endpoint, hostname):
+def resolve_ptr(tor_endpoint, ip):
     """
     This is easier to use via :meth:`txtorcon.Tor.dns_resolve_ptr`
 
     :param tor_endpoint: the Tor SOCKS endpoint to use.
 
-    :param hostname: the hostname to look up.
+    :param ip: the IP address to look up.
     """
-    if six.PY2 and isinstance(hostname, str):
-        hostname = unicode(hostname)
+    if six.PY2 and isinstance(ip, str):
+        ip = unicode(ip)
     factory = _TorSocksFactory(
-        hostname, 0, 'RESOLVE_PTR', None,
+        ip, 0, 'RESOLVE_PTR', None,
     )
     proto = yield tor_endpoint.connect(factory)
     result = yield proto.when_done()

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -656,6 +656,13 @@ def resolve(tor_endpoint, hostname):
 
 @inlineCallbacks
 def resolve_ptr(tor_endpoint, hostname):
+    """
+    This is easier to use via :meth:`txtorcon.Tor.dns_resolve_ptr`
+
+    :param tor_endpoint: the Tor SOCKS endpoint to use.
+
+    :param hostname: the hostname to look up.
+    """
     if six.PY2 and isinstance(hostname, str):
         hostname = unicode(hostname)
     factory = _TorSocksFactory(


### PR DESCRIPTION
I believe that mentioning these errors in the SOCKS5 section of the "Programming Guide" would be a good way to present them. I added the `socks` module to the docs containing only these errors because I needed a place for those classes and that looked like the right one to me. I'm not sure which other functions/classes we might want to add to this file because I think that module is a bit abstracted from the user and they might not touch those names. Is that right?

I did not add more details to the errors' docstrings but I will once I have a nice reference for that. For now I wrote that vague note until we have more info about the reasons for each error and tell the user they can find them in that module. (I should be able to do that during the week, so I think we can do everything with this same PR)

What do you think?