### PR TITLE
Improve Ephemeral Onion Service private key handling

### DIFF
--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -1303,11 +1303,13 @@ class EphemeralHiddenServiceTest(unittest.TestCase):
         self.assertEqual(eph._ports, ["80,localhost:80"])
 
     def test_wrong_blob(self):
-        try:
-            torconfig.EphemeralHiddenService("80 localhost:80", "foo")
-            self.fail("should get exception")
-        except ValueError:
-            pass
+        wrong_blobs = ["", " ", "foo", ":", " : ", "foo:", ":foo", 0]
+        for b in wrong_blobs:
+            try:
+                torconfig.EphemeralHiddenService("80 localhost:80", b)
+                self.fail("should get exception")
+            except ValueError:
+                pass
 
     def test_add(self):
         eph = torconfig.EphemeralHiddenService("80 127.0.0.1:80")

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -1320,6 +1320,15 @@ class EphemeralHiddenServiceTest(unittest.TestCase):
         self.assertEqual("blam", eph.private_key)
         self.assertEqual("ohai.onion", eph.hostname)
 
+    def test_add_keyblob(self):
+        eph = torconfig.EphemeralHiddenService("80 127.0.0.1:80", "alg:blam")
+        proto = Mock()
+        proto.queue_command = Mock(return_value="ServiceID=ohai")
+        eph.add_to_tor(proto)
+
+        self.assertEqual("alg:blam", eph.private_key)
+        self.assertEqual("ohai.onion", eph.hostname)
+
     def test_descriptor_wait(self):
         eph = torconfig.EphemeralHiddenService("80 127.0.0.1:80")
         proto = Mock()

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -1306,7 +1306,7 @@ class EphemeralHiddenServiceTest(unittest.TestCase):
         try:
             torconfig.EphemeralHiddenService("80 localhost:80", "foo")
             self.fail("should get exception")
-        except RuntimeError:
+        except ValueError:
             pass
 
     def test_add(self):

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -445,9 +445,11 @@ class EphemeralHiddenService(object):
         self.auth = auth  # FIXME ununsed
         # FIXME nicer than assert, plz
         assert isinstance(ports, list)
-        if not re.match(r'[^ :]+:[^ :]+$', key_blob_or_type):
-            raise ValueError('key_blob_or_type must be in the formats '
-                             '"NEW:<ALGORITHM>" or "<ALGORITHM>:<KEY>"')
+        if not (isinstance(key_blob_or_type, str) and
+                re.match(r'[^ :]+:[^ :]+$', key_blob_or_type)):
+            raise ValueError(
+                'key_blob_or_type must be a string in the formats '
+                '"NEW:<ALGORITHM>" or "<ALGORITHM>:<KEY>"')
 
     @defer.inlineCallbacks
     def add_to_tor(self, protocol):

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -461,7 +461,7 @@ class EphemeralHiddenService(object):
         ans = yield protocol.queue_command(cmd)
         ans = find_keywords(ans.split('\n'))
         self.hostname = ans['ServiceID'] + '.onion'
-        if self._key_blob == 'NEW:BEST':
+        if self._key_blob.startswith('NEW:'):
             self.private_key = ans['PrivateKey']
 
         log.msg('Created hidden-service at', self.hostname)

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -447,7 +447,7 @@ class EphemeralHiddenService(object):
         assert isinstance(ports, list)
         if not key_blob_or_type.startswith('NEW:') \
            and (len(key_blob_or_type) > 825 or len(key_blob_or_type) < 820):
-            raise RuntimeError('Wrong size key-blob')
+            raise ValueError('Wrong size key-blob')
 
     @defer.inlineCallbacks
     def add_to_tor(self, protocol):

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -463,6 +463,8 @@ class EphemeralHiddenService(object):
         self.hostname = ans['ServiceID'] + '.onion'
         if self._key_blob.startswith('NEW:'):
             self.private_key = ans['PrivateKey']
+        else:
+            self.private_key = self._key_blob
 
         log.msg('Created hidden-service at', self.hostname)
 

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import with_statement
 
 import os
+import re
 import six
 import functools
 import warnings
@@ -443,11 +444,10 @@ class EphemeralHiddenService(object):
         self._key_blob = key_blob_or_type
         self.auth = auth  # FIXME ununsed
         # FIXME nicer than assert, plz
-        assert ' ' not in self._key_blob
         assert isinstance(ports, list)
-        if not key_blob_or_type.startswith('NEW:') \
-           and (len(key_blob_or_type) > 825 or len(key_blob_or_type) < 820):
-            raise ValueError('Wrong size key-blob')
+        if not re.match(r'[^ :]+:[^ :]+$', key_blob_or_type):
+            raise ValueError('key_blob_or_type must be in the formats '
+                             '"NEW:<ALGORITHM>" or "<ALGORITHM>:<KEY>"')
 
     @defer.inlineCallbacks
     def add_to_tor(self, protocol):

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -424,6 +424,11 @@ class EphemeralHiddenService(object):
     https://gitweb.torproject.org/torspec.git/tree/control-spec.txt#n1295
     '''
 
+    @classmethod
+    def _is_valid_keyblob(cls, key_blob_or_type):
+        return (isinstance(key_blob_or_type, str) and
+                re.match(r'[^ :]+:[^ :]+$', key_blob_or_type))
+
     # XXX the "ports" stuff is still kind of an awkward API, especialy
     # making the actual list public (since it'll have
     # "80,127.0.0.1:80" instead of with a space
@@ -445,8 +450,7 @@ class EphemeralHiddenService(object):
         self.auth = auth  # FIXME ununsed
         # FIXME nicer than assert, plz
         assert isinstance(ports, list)
-        if not (isinstance(key_blob_or_type, str) and
-                re.match(r'[^ :]+:[^ :]+$', key_blob_or_type)):
+        if not EphemeralHiddenService._is_valid_keyblob(key_blob_or_type):
             raise ValueError(
                 'key_blob_or_type must be a string in the formats '
                 '"NEW:<ALGORITHM>" or "<ALGORITHM>:<KEY>"')


### PR DESCRIPTION
These changes seem to fix #190 and implement a different check for the type and blob provided by the user.

Right now it only checks if the key contains a `':'` and in case the type is not `'NEW'`, makes sure the blob is not empty. Should we make sure both the type and blob are not empty? Also, as an extra `AttributeError` is being catched in case the user does not provide a string (well, something that does not `split`).

I am not sure about this, but I think it is a good practice to declare all attributes in `__init__`. Is it okay to declare `hostname` and `private_key` there (by just setting them to `None`)?

We should probably add tests for these too.

Let me know what you think. Thanks!