### PR TITLE
Errback when bootstrapping the `TorConfig`

### DIFF
--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -761,7 +761,7 @@ class TorConfig(object):
         if self.protocol:
             if self.protocol.post_bootstrap:
                 self.protocol.post_bootstrap.addCallback(
-                    self.bootstrap).addErrback(log.err)
+                    self.bootstrap).addErrback(self.post_bootstrap.errback)
             else:
                 self.bootstrap()
 


### PR DESCRIPTION
So, we are planning to release a new unMessage version and recently I have been working on a few things to prevent/handle errors that might frustrate users. When we configure the control port filter, everything works fine, but I forgot to handle when a filter prevents us from acquiring the process so users get a more friendly message.

It looks like the failure occurs in `torcontrolprotocol.py` at:

```python
811         eventnames = yield self.get_info('events/names')   
```
because that command is filtered and `log.err` at the end prevents this error from being handled. I do not fully understand the bootstrapping "magic" and I am not sure if this fix is actually a fix, but makes sense to me.

Is it correct?

P.S. I intend to handle an error with a `510` code. I am not too familiar to the control spec, but do you think it would be useful (and is possible) to make classes for these too like we did for the SOCKS ones?

Thanks!