### PR TITLE
allow the client endpoint to .connect() multiple times

### DIFF
--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -764,7 +764,6 @@ class TorClientEndpoint(object):
         # socks_hostname/socks_port (in which case we do NOT want
         # guessing_enabled
         if self._socks_endpoint is None:
-            self._socks_port_iter = iter(self.socks_ports_to_try)
             self._socks_guessing_enabled = True
         else:
             self._socks_guessing_enabled = False
@@ -809,7 +808,7 @@ class TorClientEndpoint(object):
             proto = yield socks_ep.connect(protocolfactory)
             defer.returnValue(proto)
         else:
-            for socks_port in self._socks_port_iter:
+            for socks_port in self.socks_ports_to_try:
                 tor_ep = TCP4ClientEndpoint(
                     self._reactor,
                     "127.0.0.1",  # XXX socks_hostname, no?


### PR DESCRIPTION
I think StreamClientEndpoints should be reusable: you should be able to call
.connect() multiple times, yielding a different Protocol instance each time.
But the TorClientEndpoint constructor creates a single iterator to track the
sequence of possible SOCKS ports we should try, so the second time .connect()
is called, it uses the next item on this list, which will fail.

This patch removes the iterator and just loops over the original list each
time .connect() is called, removing the interaction between calls.

This ought to fix #245. I wasn't able to figure out a good unit test for it.. if you can point me in the right direction, I'll add a test and re-submit the PR.
