### PR TITLE
Port line defaults

### DIFF
--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1116,7 +1116,7 @@ class DormantTests(unittest.TestCase):
             "status/enough-dir-info": "1",
             "status/circuit-established": "1",
         })
-        ready = yield self.tor.become_ready()
+        yield self.tor.become_ready()
         self.assertTrue(
             self.tor.dns_resolve.mock_calls == []
         )
@@ -1128,7 +1128,7 @@ class DormantTests(unittest.TestCase):
             "status/enough-dir-info": "1",
             "status/circuit-established": "1",
         })
-        ready = yield self.tor.become_ready()
+        yield self.tor.become_ready()
         self.assertEqual(1, len(self.tor.dns_resolve.mock_calls))
 
 

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -146,6 +146,8 @@ class LaunchTorTests(unittest.TestCase):
             return defer.succeed('version=0.1.2.3')
         elif cmd == 'GETINFO events/names':
             return defer.succeed('events/names=STATUS_CLIENT')
+        elif cmd == 'GETINFO config/defaults':
+            return defer.succeed('config/defaults=')
         return defer.succeed(None)
 
     def _fake_event_listener(self, what, cb):
@@ -609,6 +611,8 @@ class LaunchTorTests(unittest.TestCase):
                     return defer.succeed('version=0.1.2.3')
                 elif cmd == 'GETINFO events/names':
                     return defer.succeed('events/names=STATUS_CLIENT')
+                elif cmd == 'GETINFO config/defaults':
+                    return defer.succeed('config/defaults=')
                 return defer.succeed(None)
             tpp.queue_command = fake_queue
             proto.makeConnection(Mock())

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -70,6 +70,7 @@ class EndpointTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nHiddenServiceOptions Virtual\nControlPort LineList'
         )
+        self.protocol.answers.append('')
         self.protocol.answers.append('HiddenServiceOptions')
         # why do i have to pass a dict for this V but not this ^
         self.protocol.answers.append({'ControlPort': '37337'})

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -554,7 +554,6 @@ class SocksConnectTests(unittest.TestCase):
         proto = yield ep.connect(factory)
         self.assertEqual(proto, protocol)
 
-
     @defer.inlineCallbacks
     def test_connect_tls_context(self):
         socks_ep = Mock()
@@ -574,6 +573,7 @@ class SocksConnectTests(unittest.TestCase):
         factory.buildProtocol = Mock(return_value=protocol)
 
         from OpenSSL import SSL
+
         class CertificateOptions(object):
             def getContext(self, *args, **kw):
                 return SSL.Context(SSL.TLSv1_METHOD)

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -147,6 +147,17 @@ class DefaultsTests(unittest.TestCase):
 
         self.assertEqual(config.foo, True)
 
+    @defer.inlineCallbacks
+    def test_default_linelist(self):
+        protocol = FakeControlProtocol([])
+        protocol.answers.append('config/names=\nSomeThing LineList')
+        protocol.answers.append('config/defaults=\nSomeThing value0\nSomeThing value1')
+        protocol.answers.append({'SomeThing': 'DEFAULT'})
+        config = TorConfig(protocol)
+        yield config.post_bootstrap
+
+        self.assertEqual(list(config.SomeThing), ['value0', 'value1'])
+
 
 class PortLineDefaultsTests(unittest.TestCase):
 

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -140,6 +140,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_boolean_parse_error(self):
         self.protocol.answers.append('config/names=\nfoo Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': 'bar'})
         cfg = TorConfig(self.protocol)
         return self.assertFailure(cfg.post_bootstrap, ValueError)
@@ -164,6 +165,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_boolean_parser(self):
         self.protocol.answers.append('config/names=\nfoo Boolean\nbar Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         self.protocol.answers.append({'bar': '1'})
         # FIXME does a Tor controller only ever send "0" and "1" for
@@ -175,6 +177,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_save_boolean(self):
         self.protocol.answers.append('config/names=\nfoo Boolean\nbar Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         self.protocol.answers.append({'bar': '1'})
 
@@ -189,6 +192,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_read_boolean_after_save(self):
         self.protocol.answers.append('config/names=\nfoo Boolean\nbar Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         self.protocol.answers.append({'bar': '1'})
 
@@ -203,6 +207,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_save_boolean_with_strange_values(self):
         self.protocol.answers.append('config/names=\nfoo Boolean\nbar Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         self.protocol.answers.append({'bar': '1'})
 
@@ -218,6 +223,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nfoo Boolean+Auto\nbar Boolean+Auto\nbaz Boolean+Auto'
         )
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         self.protocol.answers.append({'bar': '1'})
         self.protocol.answers.append({'baz': 'auto'})
@@ -231,6 +237,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nfoo Boolean+Auto\nbar Boolean+Auto\nbaz Boolean+Auto\nqux Boolean+Auto'
         )
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '1'})
         self.protocol.answers.append({'bar': '1'})
         self.protocol.answers.append({'baz': '1'})
@@ -256,6 +263,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nfoo Boolean+Auto'
         )
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '1'})
 
         conf = TorConfig(self.protocol)
@@ -271,18 +279,21 @@ class ConfigTests(unittest.TestCase):
 
     def test_string_parser(self):
         self.protocol.answers.append('config/names=\nfoo String')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': 'bar'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.foo, 'bar')
 
     def test_int_parser(self):
         self.protocol.answers.append('config/names=\nfoo Integer')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '123'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.foo, 123)
 
     def test_int_validator(self):
         self.protocol.answers.append('config/names=\nfoo Integer')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '123'})
         conf = TorConfig(self.protocol)
 
@@ -316,24 +327,28 @@ class ConfigTests(unittest.TestCase):
 
     def test_int_parser_error(self):
         self.protocol.answers.append('config/names=\nfoo Integer')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '123foo'})
         cfg = TorConfig(self.protocol)
         self.assertFailure(cfg.post_bootstrap, ValueError)
 
     def test_int_parser_error_2(self):
         self.protocol.answers.append('config/names=\nfoo Integer')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '1.23'})
         cfg = TorConfig(self.protocol)
         return self.assertFailure(cfg.post_bootstrap, ValueError)
 
     def test_linelist_parser(self):
         self.protocol.answers.append('config/names=\nfoo LineList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': 'bar\nbaz'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.foo, ['bar', 'baz'])
 
     def test_listlist_parser_with_list(self):
         self.protocol.answers.append('config/names=\nfoo LineList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': [1, 2, 3]})
 
         conf = TorConfig(self.protocol)
@@ -341,18 +356,21 @@ class ConfigTests(unittest.TestCase):
 
     def test_float_parser(self):
         self.protocol.answers.append('config/names=\nfoo Float')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '1.23'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.foo, 1.23)
 
     def test_float_parser_error(self):
         self.protocol.answers.append('config/names=\nfoo Float')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '1.23fff'})
         cfg = TorConfig(self.protocol)
         return self.assertFailure(cfg.post_bootstrap, ValueError)
 
     def test_list(self):
         self.protocol.answers.append('config/names=\nbing CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'bing': 'foo,bar,baz'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.config['bing'], ['foo', 'bar', 'baz'])
@@ -360,6 +378,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_single_list(self):
         self.protocol.answers.append('config/names=\nbing CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'bing': 'foo'})
         conf = TorConfig(self.protocol)
         self.assertTrue(conf.post_bootstrap.called)
@@ -367,12 +386,14 @@ class ConfigTests(unittest.TestCase):
 
     def test_multi_list_space(self):
         self.protocol.answers.append('config/names=\nbing CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'bing': 'foo, bar , baz'})
         conf = TorConfig(self.protocol)
         self.assertEqual(conf.bing, ['foo', 'bar', 'baz'])
 
     def test_descriptor_access(self):
         self.protocol.answers.append('config/names=\nbing CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'bing': 'foo,bar'})
 
         conf = TorConfig(self.protocol)
@@ -394,6 +415,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_unknown_descriptor(self):
         self.protocol.answers.append('config/names=\nbing CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'bing': 'foo'})
 
         conf = TorConfig(self.protocol)
@@ -407,6 +429,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nSomethingExciting NonExistantParserType'
         )
+        self.protocol.answers.append('')  # defaults
         cfg = TorConfig(self.protocol)
         return self.assertFailure(cfg.post_bootstrap, RuntimeError)
 
@@ -422,6 +445,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nSomethingExciting CommaList\nHiddenServices Dependant'
         )
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'SomethingExciting': 'a,b'})
         conf = TorConfig(self.protocol)
 
@@ -443,6 +467,7 @@ class ConfigTests(unittest.TestCase):
     def test_slutty_postbootstrap(self):
         # test that doPostbootstrap still works in "slutty" mode
         self.protocol.answers.append('config/names=\nORPort Port')
+        self.protocol.answers.append('')  # defaults
         # we can't answer right away, or we do all the _do_setup
         # callbacks before _setup_ is set -- but we need to do an
         # answer callback after that to trigger this bug
@@ -454,6 +479,7 @@ class ConfigTests(unittest.TestCase):
     def test_immediate_bootstrap(self):
         self.protocol.post_bootstrap = None
         self.protocol.answers.append('config/names=\nfoo Boolean')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'foo': '0'})
         conf = TorConfig(self.protocol)
         self.assertTrue('foo' in conf.config)
@@ -461,6 +487,7 @@ class ConfigTests(unittest.TestCase):
     def test_multiple_orports(self):
         self.protocol.post_bootstrap = None
         self.protocol.answers.append('config/names=\nOrPort CommaList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'OrPort': '1234'})
         conf = TorConfig(self.protocol)
         conf.OrPort = ['1234', '4321']
@@ -470,6 +497,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_set_multiple(self):
         self.protocol.answers.append('config/names=\nAwesomeKey String')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'AwesomeKey': 'foo'})
 
         conf = TorConfig(self.protocol)
@@ -488,6 +516,7 @@ class ConfigTests(unittest.TestCase):
         self.protocol.answers.append(
             'config/names=\nLog LineList\nFoo String'''
         )
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append(
             {'Log': 'notice file /var/log/tor/notices.log'}
         )
@@ -507,6 +536,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_set_save_modify(self):
         self.protocol.answers.append('config/names=\nLog LineList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append(
             {'Log': 'notice file /var/log/tor/notices.log'}
         )
@@ -521,6 +551,7 @@ class ConfigTests(unittest.TestCase):
 
     def test_proper_sets(self):
         self.protocol.answers.append('config/names=\nLog LineList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'Log': 'foo'})
 
         conf = TorConfig(self.protocol)
@@ -534,6 +565,7 @@ class ConfigTests(unittest.TestCase):
     @defer.inlineCallbacks
     def test_attach_protocol(self):
         self.protocol.answers.append('config/names=\nLog LineList')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append({'Log': 'foo'})
 
         conf = TorConfig()
@@ -570,6 +602,7 @@ class LogTests(unittest.TestCase):
     def setUp(self):
         self.protocol = FakeControlProtocol([])
         self.protocol.answers.append('config/names=\nLog LineList''')
+        self.protocol.answers.append('')  # defaults
         self.protocol.answers.append(
             {'Log': 'notice file /var/log/tor/notices.log'}
         )
@@ -733,6 +766,7 @@ class EventTests(unittest.TestCase):
         '''
         protocol = FakeControlProtocol([])
         protocol.answers.append('config/names=\nFoo Boolean\nBar Boolean')
+        protocol.answers.append('')  # defaults
         protocol.answers.append({'Foo': '0'})
         protocol.answers.append({'Bar': '1'})
 
@@ -749,6 +783,7 @@ class EventTests(unittest.TestCase):
     def test_conf_changed_invalid_values(self):
         protocol = FakeControlProtocol([])
         protocol.answers.append('config/names=\nFoo Integer\nBar Integer')
+        protocol.answers.append('')  # defaults
         protocol.answers.append({'Foo': '0'})
         protocol.answers.append({'Bar': '1'})
 
@@ -919,6 +954,7 @@ HiddenServiceOptions Virtual
 HiddenServiceVersion Dependant
 HiddenServiceDirGroupReadable Dependant
 HiddenServiceAuthorizeClient Dependant''')
+        self.protocol.answers.append('')  # defaults
 
     @defer.inlineCallbacks
     def test_options_hidden(self):

--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -657,9 +657,9 @@ class Tor(object):
         )
         returnValue(
             not(
-                int(info["dormant"])
-                or not int(info["status/enough-dir-info"])
-                or not int(info["status/circuit-established"])
+                int(info["dormant"]) or
+                not int(info["status/enough-dir-info"]) or
+                not int(info["status/circuit-established"])
             )
         )
 
@@ -675,7 +675,6 @@ class Tor(object):
         if not ready:
             yield self.dns_resolve(u'torproject.org')
         return
-
 
     @inlineCallbacks
     def _default_socks_endpoint(self):

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1170,7 +1170,7 @@ class TorConfig(object):
             # "FooPortLines"
             if name.endswith('PortLines'):
                 rn = self._find_real_name(name[:-5])
-                self.parsers[rn] = Port()
+                self.parsers[rn] = String()  # not Port() because options etc
                 self.list_parsers.add(rn)
                 v = yield self.protocol.get_conf(name[:-5])
                 v = v[name[:-5]]

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1176,11 +1176,13 @@ class TorConfig(object):
                 v = yield self.protocol.get_conf(name[:-5])
                 v = v[name[:-5]]
 
-                if v == DEFAULT_VALUE or v == 'auto':
-                    v = defaults.get(v, None)
-
                 initial = []
-                if v is not None:
+                if v == DEFAULT_VALUE or v == 'auto':
+                    try:
+                        initial = defaults[name[:-5]]
+                    except KeyError:
+                        initial = []
+                else:
                     initial = [self.parsers[rn].parse(v)]
                 self.config[rn] = _ListWrapper(
                     initial, functools.partial(self.mark_unsaved, rn))
@@ -1216,7 +1218,11 @@ class TorConfig(object):
                     parsed, functools.partial(self.mark_unsaved, rn))
 
             else:
-                self.config[rn] = self.parsers[rn].parse(v)
+                if v == '' or v == DEFAULT_VALUE:
+                    parsed = self.parsers[rn].parse(defaults.get(rn, DEFAULT_VALUE))
+                else:
+                    parsed = self.parsers[rn].parse(v)
+                self.config[rn] = parsed
 
         # can't just return in @inlineCallbacks-decorated methods
         defer.returnValue(self)

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -762,6 +762,7 @@ class TorConfig(object):
         self._supports = dict(
             HiddenServiceDirGroupReadable=False
         )
+        self._defaults = dict()
 
         self.post_bootstrap = defer.Deferred()
         if self.protocol:


### PR DESCRIPTION
Handle all the `*PortLines` options properly, and also handle defaults better overall.