### PR TITLE
onions on unix sockets

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -74,6 +74,7 @@ unreleased
  * :method:`txtorcon.Tor.onion_authentication` (Python3 only) an async
    context-manager that adds and removes an Onion authentication token
    (i.e. adds in on `__aenter__` and removes it on `__aexit__`).
+ * onion services support listening on Unix paths.
 
 
 v0.20.0

--- a/examples/web_onion_service_ephemeral_unix.py
+++ b/examples/web_onion_service_ephemeral_unix.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# This shows how to leverage the endpoints API to get a new hidden
+# service up and running quickly. You can pass along this API to your
+# users by accepting endpoint strings as per Twisted recommendations.
+#
+# http://twistedmatrix.com/documents/current/core/howto/endpoints.html#maximizing-the-return-on-your-endpoint-investment
+#
+# note that only the progress-updates needs the "import txtorcon" --
+# you do still need it installed so that Twisted finds the endpoint
+# parser plugin but code without knowledge of txtorcon can still
+# launch a Tor instance using it. cool!
+
+from __future__ import print_function
+from os.path import abspath
+
+from twisted.internet import defer, task, endpoints
+from twisted.web import server, resource
+
+import txtorcon
+from txtorcon.util import default_control_port
+from txtorcon.onion import AuthBasic
+
+
+class Simple(resource.Resource):
+    """
+    A really simple Web site.
+    """
+    isLeaf = True
+
+    def render_GET(self, request):
+        return b"<html>Hello, world! I'm an authenticated hidden service!</html>"
+
+
+@defer.inlineCallbacks
+def main(reactor):
+    tor = yield txtorcon.connect(
+        reactor,
+        endpoints.TCP4ClientEndpoint(reactor, "localhost", 9051),
+    )
+    unix_p = abspath('./web_socket')
+
+    ep = endpoints.UNIXServerEndpoint(reactor, unix_p)
+    port = yield ep.listen(server.Site(Simple()))
+
+    def on_progress(percent, tag, msg):
+        print('%03d: %s' % (percent, msg))
+    print("Note: descriptor upload can take several minutes")
+    onion = yield tor.create_onion_service(
+        ports=[(80, 'unix:{}'.format(unix_p))],
+        version=3,  # or try version=2 if you have an older Tor
+        progress=on_progress,
+    )
+
+    print("Private key:\n{}".format(onion.private_key))
+    print("{}".format(onion.hostname))
+    yield defer.Deferred()  # wait forever
+
+
+task.react(main)

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1282,6 +1282,11 @@ class EphemeralOnionFactoryTests(unittest.TestCase):
         yield _validate_ports(Mock(), [80])
 
     @defer.inlineCallbacks
+    def test_ports_contain_non_ints_unix_ok(self):
+        from txtorcon.controller import _validate_ports
+        yield _validate_ports(Mock(), [(80, "unix:/dev/null")])
+
+    @defer.inlineCallbacks
     def test_ports_contain_2_tuple(self):
         from txtorcon.controller import _validate_ports
         yield _validate_ports(Mock(), [(80, 54321)])

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1268,7 +1268,7 @@ class EphemeralOnionFactoryTests(unittest.TestCase):
     def test_ports_contain_non_ints4(self):
         with self.assertRaises(ValueError) as ctx:
             yield self.tor.create_onion_service([('1234', 'bad')])
-        self.assertIn("non-integer", str(ctx.exception))
+        self.assertIn("be either an integer", str(ctx.exception))
 
     @defer.inlineCallbacks
     def test_ports_contain_non_ints5(self):


### PR DESCRIPTION
Parsers allow local ports to be unix-sockets; this lets ephemeral and non-ephemeral services listen
over unix sockets (so long as the tor we're connected to
supports that).