### PR TITLE
figure out if we have async in an even more robust way

### DIFF
--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -42,7 +42,7 @@ from .interface import ITor
 try:
     from .controller_py3 import _AsyncOnionAuthContext
     HAVE_ASYNC = True
-except SyntaxError:
+except Exception:
     HAVE_ASYNC = False
 
 if sys.platform in ('linux', 'linux2', 'darwin'):


### PR DESCRIPTION
On Ubuntu we don't ship controller_py3.py for Python 2.7 because parsing it during installation breaks the installation.
The missing file triggers ModuleNotFoundError instead of SyntaxError and IMO catching Exception and continuing with no async is semantically as correct as listing the potential subclasses.