### PR TITLE
non anonymous services

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -23,6 +23,7 @@ unreleased
 
  * add `privateKeyFile=` option to endpoint parser (ticket 313)
  * use `privateKey=` option properly in endpoint parser
+ * support `NonAnonymous` mode for `ADD_ONION` via `single_hop=` kwarg
 
 
 v18.1.0

--- a/examples/web_onion_service_ephemeral_nonanon.py
+++ b/examples/web_onion_service_ephemeral_nonanon.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Here we use some very new Tor configuration options to set up a
+# "single-hop" or "non-anonymous" onion service. These do NOT give the
+# server location-privacy, so may be appropriate for certain kinds of
+# services. Once you publish a service like this, there's no going
+# back to location-hidden.
+
+from __future__ import print_function
+from twisted.internet import defer, task, endpoints
+from twisted.web import server, resource
+
+import txtorcon
+from txtorcon.util import default_control_port
+from txtorcon.onion import AuthBasic
+
+
+class Simple(resource.Resource):
+    """
+    A really simple Web site.
+    """
+    isLeaf = True
+
+    def render_GET(self, request):
+        return b"<html>Hello, world! I'm a single-hop onion service!</html>"
+
+
+@defer.inlineCallbacks
+def main(reactor):
+    # For the "single_hop=True" below to work, the Tor we're
+    # connecting to must have the following options set:
+    # SocksPort 0
+    # HiddenServiceSingleHopMode 1
+    # HiddenServiceNonAnonymousMode 1
+
+    tor = yield txtorcon.connect(
+        reactor,
+        endpoints.TCP4ClientEndpoint(reactor, "localhost", 9351),
+    )
+    ep = tor.create_onion_endpoint(
+        80,
+        version=3,
+        single_hop=True,
+    )
+
+    def on_progress(percent, tag, msg):
+        print('%03d: %s' % (percent, msg))
+    txtorcon.IProgressProvider(ep).add_progress_listener(on_progress)
+
+    port = yield ep.listen(server.Site(Simple()))
+    print("Private key:\n{}".format(port.getHost().onion_key))
+    hs = port.onion_service
+    print("Site on http://{}".format(hs.hostname))
+    yield defer.Deferred()  # wait forever
+
+
+task.react(main)

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -548,6 +548,18 @@ class EndpointTests(unittest.TestCase):
         ep._tor_progress_update(40, "FOO", "foo to bar")
         return ep
 
+    def test_single_hop_non_ephemeral(self, ftb):
+        control_ep = Mock()
+        control_ep.connect = Mock(return_value=defer.succeed(None))
+        directlyProvides(control_ep, IStreamClientEndpoint)
+        with self.assertRaises(ValueError) as ctx:
+            TCPHiddenServiceEndpoint.system_tor(
+                self.reactor, control_ep, 1234,
+                ephemeral=False,
+                single_hop=True,
+            )
+        self.assertIn("single_hop=", str(ctx.exception))
+
     def test_progress_updates_global_tor(self, ftb):
         with patch('txtorcon.endpoints.get_global_tor_instance') as tor:
             ep = TCPHiddenServiceEndpoint.global_tor(self.reactor, 1234)

--- a/test/test_onion.py
+++ b/test/test_onion.py
@@ -281,6 +281,24 @@ class OnionServiceTest(unittest.TestCase):
         self.assertEqual(u"ADD_ONION NEW:ED25519-V3 Port=80,192.168.1.2:80 Flags=Detach", cmd)
         d.callback("PrivateKey={}\nServiceID={}".format(_test_private_key_blob, _test_onion_id))
 
+    def test_ephemeral_v3_non_anonymous(self):
+        protocol = FakeControlProtocol([])
+        config = TorConfig(protocol)
+
+        # returns a Deferred we're ignoring
+        EphemeralOnionService.create(
+            Mock(),
+            config,
+            ports=[(80, "192.168.1.2:80")],
+            version=3,
+            detach=True,
+            single_hop=True,
+        )
+
+        cmd, d = protocol.commands[0]
+        self.assertEqual(u"ADD_ONION NEW:ED25519-V3 Port=80,192.168.1.2:80 Flags=Detach,NonAnonymous", cmd)
+        d.callback("PrivateKey={}\nServiceID={}".format(_test_private_key_blob, _test_onion_id))
+
     @defer.inlineCallbacks
     def test_ephemeral_v3_ip_addr_tuple_non_local(self):
         protocol = FakeControlProtocol([])

--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -755,7 +755,7 @@ class Tor(object):
             auth=auth,
         )
 
-    def create_onion_endpoint(self, port, private_key=None, version=None):
+    def create_onion_endpoint(self, port, private_key=None, version=None, single_hop=None):
         """
         WARNING: API subject to change
 
@@ -778,6 +778,11 @@ class Tor(object):
         :param version: if not None, a specific version of service to
             use; version=3 is Proposition 224 and version=2 is the
             older 1024-bit key based implementation.
+
+        :param single_hop: if True, pass the `NonAnonymous` flag. Note
+            that Tor options `HiddenServiceSingleHopMode`,
+            `HiddenServiceNonAnonymousMode` must be set to `1` and there
+            must be no `SOCKSPort` configured for this to actually work.
         """
         # note, we're just depending on this being The Ultimate
         # Everything endpoint. Which seems fine, because "normal"
@@ -791,6 +796,7 @@ class Tor(object):
             private_key=private_key,
             version=version,
             auth=None,
+            single_hop=single_hop,
         )
 
     def create_filesystem_onion_endpoint(self, port, hs_dir, group_readable=False, version=None):
@@ -939,7 +945,7 @@ class Tor(object):
     # method names are kind of long (not-ideal)
 
     @inlineCallbacks
-    def create_onion_service(self, ports, private_key=None, version=3, progress=None, await_all_uploads=False):
+    def create_onion_service(self, ports, private_key=None, version=3, progress=None, await_all_uploads=False, single_hop=None):
         """
         Create a new Onion service
 
@@ -975,6 +981,11 @@ class Tor(object):
             until at least one upload of our Descriptor to a Directory
             Authority has completed; if True we wait until all have
             completed.
+
+        :param single_hop: if True, pass the `NonAnonymous` flag. Note
+            that Tor options `HiddenServiceSingleHopMode`,
+            `HiddenServiceNonAnonymousMode` must be set to `1` and there
+            must be no `SOCKSPort` configured for this to actually work.
         """
         if version not in (2, 3):
             raise ValueError(
@@ -993,6 +1004,7 @@ class Tor(object):
             version=version,
             progress=progress,
             await_all_uploads=await_all_uploads,
+            single_hop=single_hop,
         )
         returnValue(service)
 

--- a/txtorcon/onion.py
+++ b/txtorcon/onion.py
@@ -193,6 +193,10 @@ class FilesystemOnionService(object):
         :param progress: a callable taking (percent, tag, description)
             that is called periodically to report progress.
 
+        :param await_all_uploads: if True, the Deferred only fires
+            after ALL descriptor uploads have completed (otherwise, it
+            fires when at least one has completed).
+
         See also :meth:`txtorcon.Tor.create_onion_service` (which
         ultimately calls this).
         """
@@ -1095,6 +1099,10 @@ class FilesystemAuthenticatedOnionService(object):
 
         :param progress: a callable taking (percent, tag, description)
             that is called periodically to report progress.
+
+        :param await_all_uploads: if True, the Deferred only fires
+            after ALL descriptor uploads have completed (otherwise, it
+            fires when at least one has completed).
         """
         # if hsdir is relative, it's "least surprising" (IMO) to make
         # it into a relative path here -- otherwise, it's relative to

--- a/txtorcon/onion.py
+++ b/txtorcon/onion.py
@@ -576,6 +576,8 @@ def _add_ephemeral_service(config, onion, progress, version, auth=None, await_al
         assert isinstance(auth, AuthBasic)  # don't support AuthStealth yet
         if isinstance(auth, AuthBasic):
             flags.append('BasicAuth')
+    if onion._single_hop:
+        flags.append('NonAnonymous')  # depends on some Tor options, too
     if flags:
         cmd += ' Flags={}'.format(','.join(flags))
 
@@ -674,7 +676,8 @@ class EphemeralAuthenticatedOnionService(object):
                version=None,
                progress=None,
                auth=None,
-               await_all_uploads=None):  # AuthBasic, or AuthStealth instance
+               await_all_uploads=None,   # AuthBasic, or AuthStealth instance
+               single_hop=False):
 
         """
         returns a new EphemeralAuthenticatedOnionService after adding it
@@ -697,6 +700,15 @@ class EphemeralAuthenticatedOnionService(object):
 
         :param progress: a callable taking (percent, tag, description)
             that is called periodically to report progress.
+
+        :param await_all_uploads: if True, the Deferred only fires
+            after ALL descriptor uploads have completed (otherwise, it
+            fires when at least one has completed).
+
+        :param single_hop: if True, pass the `NonAnonymous` flag. Note
+            that Tor options `HiddenServiceSingleHopMode`,
+            `HiddenServiceNonAnonymousMode` must be set to `1` and there
+            must be no `SOCKSPort` configured for this to actually work.
 
         See also :meth:`txtorcon.Tor.create_onion_service` (which
         ultimately calls this).
@@ -721,13 +733,14 @@ class EphemeralAuthenticatedOnionService(object):
             private_key=private_key,
             detach=detach,
             version=version,
+            single_hop=single_hop,
         )
         yield _add_ephemeral_service(config, onion, progress, version, auth, await_all_uploads)
 
         defer.returnValue(onion)
 
     def __init__(self, config, ports, hostname=None, private_key=None, auth=[], version=3,
-                 detach=False):
+                 detach=False, single_hop=None):
         """
         Users should create instances of this class by using the async
         method :meth:`txtorcon.EphemeralAuthenticatedOnionService.create`
@@ -742,6 +755,7 @@ class EphemeralAuthenticatedOnionService(object):
         self._version = version
         self._detach = detach
         self._clients = dict()
+        self._single_hop = single_hop
 
     def get_permanent_id(self):
         """
@@ -824,7 +838,8 @@ class EphemeralOnionService(object):
                private_key=None,  # or DISCARD
                version=None,
                progress=None,
-               await_all_uploads=None):
+               await_all_uploads=None,
+               single_hop=False):
         """
         returns a new EphemeralOnionService after adding it to the
         provided config and ensuring at least one of its descriptors
@@ -847,6 +862,15 @@ class EphemeralOnionService(object):
         :param progress: a callable taking (percent, tag, description)
             that is called periodically to report progress.
 
+        :param await_all_uploads: if True, the Deferred only fires
+            after ALL descriptor uploads have completed (otherwise, it
+            fires when at least one has completed).
+
+        :param single_hop: if True, pass the `NonAnonymous` flag. Note
+            that Tor options `HiddenServiceSingleHopMode`,
+            `HiddenServiceNonAnonymousMode` must be set to `1` and there
+            must be no `SOCKSPort` configured for this to actually work.
+
         See also :meth:`txtorcon.Tor.create_onion_service` (which
         ultimately calls this).
         """
@@ -862,6 +886,7 @@ class EphemeralOnionService(object):
             detach=detach,
             version=version,
             await_all_uploads=await_all_uploads,
+            single_hop=single_hop,
         )
 
         yield _add_ephemeral_service(config, onion, progress, version, None, await_all_uploads)
@@ -869,7 +894,7 @@ class EphemeralOnionService(object):
         defer.returnValue(onion)
 
     def __init__(self, config, ports, hostname=None, private_key=None, version=3,
-                 detach=False, await_all_uploads=None, **kwarg):
+                 detach=False, await_all_uploads=None, single_hop=None, **kwarg):
         """
         Users should create instances of this class by using the async
         method :meth:`txtorcon.EphemeralOnionService.create`
@@ -893,6 +918,7 @@ class EphemeralOnionService(object):
         self._private_key = private_key
         self._version = version
         self._detach = detach
+        self._single_hop = single_hop
 
     # not putting an "add_to_tor" method here; that class is now
     # deprecated and you add one of these by using .create()


### PR DESCRIPTION
See #315 

"launch()" should probably support the right option(s) too, but .. tor doesn't bootstrap if you start it with the two relevant options but *without* any Onion Services defined on the command-line as well (see https://github.com/meejah/txtorcon/pull/318 for that implementation thus far).

See https://trac.torproject.org/projects/tor/ticket/27849 which is the "tor doesn't bootstrap" bug described above.