### PR TITLE
non anonymous services  (launch)

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -21,6 +21,12 @@ unreleased
 
 `git master <https://github.com/meejah/txtorcon>`_ *will likely become v19.0.0*
 
+ * introduce `non_anonymous_mode=` kwarg in :func:`txtorcon.launch`
+   enabling Tor options making Onion Services non-anonymous for the
+   server (but they use a single hop instead of three to the
+   Introduction Point so they're slightly faster).
+
+
 v18.3.0
 -------
 

--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -55,6 +55,7 @@ def launch(reactor,
            control_port=None,
            data_directory=None,
            socks_port=None,
+           non_anonymous_mode=None,
            stdout=None,
            stderr=None,
            timeout=None,
@@ -109,6 +110,14 @@ def launch(reactor,
         etc); starting with an already-populated state directory is a lot
         faster. If ``None`` (the default), we create a tempdir for this
         **and delete it on exit**. It is recommended you pass something here.
+
+    :param non_anonymous_mode: sets the Tor options
+        `HiddenServiceSingleHopMode` and
+        `HiddenServiceNonAnonymousMode` to 1 and un-sets any
+        `SOCKSPort` config, thus putting this Tor client into
+        "non-anonymous mode" which allows starting so-called Single
+        Onion services -- which use single-hop circuits to rendezvous
+        points. See WARNINGs in Tor manual!
 
     :param stdout: a file-like object to which we write anything that
         Tor prints on stdout (just needs to support write()).
@@ -221,9 +230,18 @@ def launch(reactor,
         except KeyError:
             socks_port = None
 
-    if socks_port is None:
-        socks_port = yield available_tcp_port(reactor)
-    config.SOCKSPort = socks_port
+    if non_anonymous_mode:
+        if socks_port is not None:
+            raise ValueError(
+                "Cannot use SOCKS options with non_anonymous_mode=True"
+            )
+        config.HiddenServiceNonAnonymousMode = 1
+        config.HiddenServiceSingleHopMode = 1
+        config.SOCKSPort = 0
+    else:
+        if socks_port is None:
+            socks_port = yield available_tcp_port(reactor)
+        config.SOCKSPort = socks_port
 
     try:
         our_user = user or config.User
@@ -350,6 +368,7 @@ def launch(reactor,
             config.protocol,
             _tor_config=config,
             _process_proto=process_protocol,
+            _non_anonymous=True if non_anonymous_mode else False,
         )
     )
 
@@ -474,7 +493,7 @@ class Tor(object):
             print(port.getHost())
     """
 
-    def __init__(self, reactor, control_protocol, _tor_config=None, _process_proto=None):
+    def __init__(self, reactor, control_protocol, _tor_config=None, _process_proto=None, _non_anonymous=None):
         """
         don't instantiate this class yourself -- instead use the factory
         methods :func:`txtorcon.launch` or :func:`txtorcon.connect`
@@ -487,6 +506,8 @@ class Tor(object):
         # cache our preferred socks port (please use
         # self._default_socks_endpoint() to get one)
         self._socks_endpoint = None
+        # True if we've turned on non-anonymous mode / Onion services
+        self._non_anonymous = _non_anonymous
 
     @inlineCallbacks
     def quit(self):
@@ -552,6 +573,10 @@ class Tor(object):
 
         :param pool: passed on to the Agent (as ``pool=``)
         """
+        if self._non_anonymous:
+            raise Exception(
+                "Cannot use web_agent when in non_anonymous mode"
+            )
         # local import since not all platforms have this
         from txtorcon import web
 
@@ -932,6 +957,10 @@ class Tor(object):
         (which might mean setting one up in our attacked Tor if it
         doesn't have one)
         """
+        if self._non_anonymous:
+            raise Exception(
+                "Cannot use SOCKS when in non_anonymous mode"
+            )
         if self._socks_endpoint is None:
             self._socks_endpoint = yield _create_socks_endpoint(self._reactor, self._protocol)
         returnValue(self._socks_endpoint)

--- a/txtorcon/onion.py
+++ b/txtorcon/onion.py
@@ -170,7 +170,11 @@ class FilesystemOnionService(object):
 
     @staticmethod
     @defer.inlineCallbacks
-    def create(reactor, config, hsdir, ports, version=3, group_readable=False, progress=None, await_all_uploads=None):
+    def create(reactor, config, hsdir, ports,
+               version=3,
+               group_readable=False,
+               progress=None,
+               await_all_uploads=None):
         """
         returns a new FilesystemOnionService after adding it to the
         provided config and ensuring at least one of its descriptors
@@ -1076,7 +1080,12 @@ class FilesystemAuthenticatedOnionService(object):
 
     @staticmethod
     @defer.inlineCallbacks
-    def create(reactor, config, hsdir, ports, auth=None, version=3, group_readable=False, progress=None, await_all_uploads=None):
+    def create(reactor, config, hsdir, ports,
+               auth=None,
+               version=3,
+               group_readable=False,
+               progress=None,
+               await_all_uploads=None):
         """
         returns a new FilesystemAuthenticatedOnionService after adding it
         to the provided config and ensureing at least one of its


### PR DESCRIPTION
Adds a "launch()" implementation as well (this doesn't actually work though, because Tor doesn't get past 0% bootstrapping unless you include at least one `HiddenServiceDir` on the command-line too).

See https://trac.torproject.org/projects/tor/ticket/27849 which is the "tor doesn't bootstrap" bug described above.