### PR TITLE
Ticket226 control port status

### DIFF
--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -51,7 +51,7 @@ class FakeProcessTransport(proto_helpers.StringTransportWithDisconnection):
         )
 
     def closeStdin(self):
-        self.process_protocol.outReceived(b"100%")
+        self.process_protocol.outReceived(b"Opening Control listener")
         return
 
 
@@ -599,7 +599,7 @@ class LaunchTorTests(unittest.TestCase):
         trans = FakeProcessTransport()
 
         def on_protocol(proto):
-            proto.outReceived(b'Bootstrapped 100%\n')
+            proto.outReceived(b'Opening Control listener\n')
         reactor = FakeReactor(self, trans, on_protocol, [1, 2, 3])
 
         fails = ['one']

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -51,7 +51,7 @@ class FakeProcessTransport(proto_helpers.StringTransportWithDisconnection):
         )
 
     def closeStdin(self):
-        self.process_protocol.outReceived(b"Bootstrap")
+        self.process_protocol.outReceived(b"100%")
         return
 
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -1347,7 +1347,7 @@ class FakeReactorTcp(object):
         self.transport.protocol = self.protocol
 
         def blam():
-            self.protocol.outReceived(b"bootstrap")
+            self.protocol.outReceived(b"Bootstrap")
         self.transport.closeStdin = blam
         self.protocol.makeConnection(self.transport)
         self.test = test

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -1347,7 +1347,7 @@ class FakeReactorTcp(object):
         self.transport.protocol = self.protocol
 
         def blam():
-            self.protocol.outReceived(b"100%")
+            self.protocol.outReceived(b"bootstrap")
         self.transport.closeStdin = blam
         self.protocol.makeConnection(self.transport)
         self.test = test

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -1347,7 +1347,7 @@ class FakeReactorTcp(object):
         self.transport.protocol = self.protocol
 
         def blam():
-            self.protocol.outReceived(b"Bootstrap")
+            self.protocol.outReceived(b"100%")
         self.transport.closeStdin = blam
         self.protocol.makeConnection(self.transport)
         self.test = test

--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -1234,7 +1234,7 @@ class TorProcessProtocol(protocol.ProcessProtocol):
         # tor_connection_failed)
         txtorlog.msg(data)
         if not self.attempted_connect and self.connection_creator \
-                and b'100%' in data:
+                and b'Opening Control listener' in data:
             self.attempted_connect = True
             # hmmm, we don't "do" anything with this Deferred?
             # (should it be connected to the when_connected

--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -1234,7 +1234,7 @@ class TorProcessProtocol(protocol.ProcessProtocol):
         # tor_connection_failed)
         txtorlog.msg(data)
         if not self.attempted_connect and self.connection_creator \
-                and b'Bootstrap' in data:
+                and b'100%' in data:
             self.attempted_connect = True
             # hmmm, we don't "do" anything with this Deferred?
             # (should it be connected to the when_connected


### PR DESCRIPTION
Easy enough start to check for 'Opening Control listener' over checking every line for bootstrap. Edited the tests. Next steps could be parsing only a few lines?

Do we need to error handle when control port is not set?

Thanks