### PR TITLE
Adding support for 3.8 abstract base classes

### DIFF
--- a/txtorcon/controller.py
+++ b/txtorcon/controller.py
@@ -11,8 +11,11 @@ import shlex
 import tempfile
 import functools
 from io import StringIO
-from collections import Sequence
 from os.path import dirname, exists
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from twisted.python import log
 from twisted.python.failure import Failure

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -10,8 +10,11 @@ import six
 import functools
 import warnings
 from io import StringIO
-from collections import OrderedDict
 from warnings import warn
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 from twisted.python import log
 from twisted.python.compat import nativeString


### PR DESCRIPTION
Quick fix for the abc change in 3.8.

Please let me know etiquette wise where a try block like this should go for imports.