### PR TITLE
test: mock is now a build in Python module

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,6 @@ wheel
 twine
 pyflakes
 pycodestyle
-mock
 ipaddress>=1.0.16
 geoip
 readme_renderer

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -15,7 +15,6 @@ wheel
 twine
 pyflakes
 pycodestyle
-mock
 ipaddress>=1.0.16
 geoip
 readme_renderer

--- a/test/py3_test_controller.py
+++ b/test/py3_test_controller.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.trial import unittest
 from twisted.internet.defer import ensureDeferred

--- a/test/test_attacher.py
+++ b/test/test_attacher.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from zope.interface import directlyProvides
 
 from twisted.trial import unittest

--- a/test/test_circuit.py
+++ b/test/test_circuit.py
@@ -1,6 +1,6 @@
 import datetime
 import ipaddress
-from mock import patch
+from unittest.mock import patch
 
 from twisted.trial import unittest
 from twisted.internet import defer
@@ -21,7 +21,7 @@ from txtorcon.interface import ICircuitContainer
 from txtorcon.interface import CircuitListenerMixin
 from txtorcon.interface import ITorControlProtocol
 
-from mock import Mock
+from unittest.mock import Mock
 
 
 @implementer(IRouterContainer)

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -2,7 +2,7 @@ import os
 import six
 import functools
 from os.path import join
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from io import BytesIO
 
 from twisted.internet.interfaces import IReactorCore

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 
 import os
 import sys
-from mock import patch
-from mock import Mock, MagicMock
+from unittest.mock import patch
+from unittest.mock import Mock, MagicMock
 from unittest import skipIf
 from binascii import b2a_base64
 

--- a/test/test_onion.py
+++ b/test/test_onion.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import os
 import sys
-from mock import Mock
+from unittest.mock import Mock
 from os.path import join
 from unittest import skipIf
 

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.trial import unittest
 from twisted.internet import defer

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -1,5 +1,5 @@
 from six import BytesIO, text_type
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from twisted.trial import unittest
 from twisted.internet import defer

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -6,7 +6,7 @@ import tempfile
 import functools
 import warnings
 from six import StringIO
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from os.path import join
 
 from zope.interface import implementer, directlyProvides

--- a/test/test_torstate.py
+++ b/test/test_torstate.py
@@ -12,7 +12,7 @@ import tempfile
 
 from ipaddress import IPv4Address
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from txtorcon import TorControlProtocol
 from txtorcon import TorProtocolError

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import ipaddress
-from mock import patch
+from unittest.mock import patch
 from unittest import skip as _skip
 from os.path import exists
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1,5 +1,5 @@
 
-from mock import Mock
+from unittest.mock import Mock
 
 from twisted.web.client import BrowserLikePolicyForHTTPS
 from twisted.trial import unittest

--- a/test3/test_controller.py
+++ b/test3/test_controller.py
@@ -2,7 +2,7 @@
 
 import six
 import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from zope.interface import directlyProvides
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps=
     zope.interface>=3.6.1
     setuptools>=0.8.0
     automat
-    mock
 ## XXX this doesn't work on github-actions
 ##    GeoIP
     coverage


### PR DESCRIPTION
Since Python 3.3 mock is now also provided by unittest so a dependency on mock is no longer required.