### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/examples/web_onion_service_endpoints.py
+++ b/examples/web_onion_service_endpoints.py
@@ -56,7 +56,7 @@ def main(reactor):
         port = yield ep.listen(server.Site(Simple()))
     except error.ConnectionRefusedError:
         print("Couldn't connect; is Tor listening on localhost:{}?".format(default_control_port()))
-        defer.returnValue(1)
+        return 1
 
     print("Site listening: {}".format(port.getHost()))
     print("Private key:\n{}".format(port.getHost().onion_key))

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -627,8 +627,7 @@ class EndpointTests(unittest.TestCase):
             yield arg.stopListening()
             ep.listen(NoOpProtocolFactory())
 
-            defer.returnValue(arg)
-            return
+            return arg
         d0.addBoth(more_listen)
         self.protocol.commands[0][1].callback(
             'ServiceID=blarglyfoo\nPrivateKey=bigbadkeyblob'
@@ -662,8 +661,7 @@ class EndpointTests(unittest.TestCase):
             yield arg.stopListening()
             ep.listen(NoOpProtocolFactory())
 
-            defer.returnValue(arg)
-            return
+            return arg
         d0.addBoth(more_listen)
         if True:
             self.protocol.events['HS_DESC'](

--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -1457,11 +1457,8 @@ class LegacyLaunchTorTests(unittest.TestCase):
             )
             self.assertIs(tpp, fake_tor.process)
         calls = warn.mock_calls
-        # on Twisted 24.7.0 and higher, there's an extra deprecation
-        # warning due to returnValue being deprecated
-        self.assertTrue(len(calls) >= 1)
-        for call in calls:
-            self.assertEqual(call[1][1], DeprecationWarning)
+        self.assertEqual(1, len(calls))
+        self.assertEqual(calls[0][1][1], DeprecationWarning)
 
 
 class ErrorTests(unittest.TestCase):

--- a/txtorcon/circuit.py
+++ b/txtorcon/circuit.py
@@ -104,7 +104,7 @@ class _CircuitAttacher(object):
                 )))
                 return
             d.callback(None)
-            defer.returnValue(circuit)
+            return circuit
         except Exception:
             d.errback(Failure())
 
@@ -114,7 +114,7 @@ def _get_circuit_attacher(reactor, state):
     if _get_circuit_attacher.attacher is None:
         _get_circuit_attacher.attacher = _CircuitAttacher()
         yield state.set_attacher(_get_circuit_attacher.attacher, reactor)
-    defer.returnValue(_get_circuit_attacher.attacher)
+    return _get_circuit_attacher.attacher
 
 
 _get_circuit_attacher.attacher = None
@@ -150,7 +150,7 @@ class TorCircuitEndpoint(object):
         attached_d = attacher.add_endpoint(self._target_endpoint, self._circuit)
         proto = yield connect_d
         yield attached_d
-        defer.returnValue(proto)
+        return proto
 
 
 class Circuit(object):

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -96,7 +96,7 @@ def get_global_tor_instance(reactor,
                     control_port,
                 )
 
-        defer.returnValue(_global_tor)
+        return _global_tor
     finally:
         _global_tor_lock.release()
 
@@ -131,7 +131,7 @@ def get_global_tor(reactor, control_port=None,
         _tor_launcher=_tor_launcher,
     )
     cfg = yield tor.get_config()
-    defer.returnValue(cfg)
+    return cfg
 
 
 class IProgressProvider(Interface):
@@ -669,13 +669,11 @@ class TCPHiddenServiceEndpoint(object):
         # (so can provide .local_port -> shoujld be local_endpoint I
         # guess actually...)
         # 2. anyway, can provide access to the "real" hs anyway if we want
-        defer.returnValue(
-            TorOnionListeningPort(
-                self.tcp_listening_port,
-                self.public_port,
-                self.hiddenservice,
-                self._config,
-            )
+        return TorOnionListeningPort(
+            self.tcp_listening_port,
+            self.public_port,
+            self.hiddenservice,
+            self._config,
         )
 
 
@@ -1033,7 +1031,7 @@ def _create_socks_endpoint(reactor, control_protocol, socks_config=None):
         socks_endpoint = _endpoint_from_socksport_line(reactor, socks_config)
 
     assert socks_endpoint is not None
-    defer.returnValue(socks_endpoint)
+    return socks_endpoint
 
 
 @implementer(IStreamClientEndpoint)
@@ -1160,7 +1158,7 @@ class TorClientEndpoint(object):
             # forward the address to any listeners we have
             socks_ep._get_address().addCallback(self._when_address.fire)
             proto = yield socks_ep.connect(protocolfactory)
-            defer.returnValue(proto)
+            return proto
         else:
             for socks_port in self.socks_ports_to_try:
                 tor_ep = TCP4ClientEndpoint(
@@ -1173,7 +1171,7 @@ class TorClientEndpoint(object):
                 socks_ep._get_address().addCallback(self._when_address.fire)
                 try:
                     proto = yield socks_ep.connect(protocolfactory)
-                    defer.returnValue(proto)
+                    return proto
 
                 except error.ConnectError as e0:
                     last_error = e0

--- a/txtorcon/onion.py
+++ b/txtorcon/onion.py
@@ -251,7 +251,7 @@ class FilesystemOnionService(object):
 
         yield config.save()
         yield uploaded[0]
-        defer.returnValue(fhs)
+        return fhs
 
     def __init__(self, config, thedir, ports, version=3, group_readable=0):
         """
@@ -744,7 +744,7 @@ class EphemeralAuthenticatedOnionService(object):
         )
         yield _add_ephemeral_service(config, onion, progress, version, auth, await_all_uploads)
 
-        defer.returnValue(onion)
+        return onion
 
     def __init__(self, config, ports, hostname=None, private_key=None, auth=[], version=3,
                  detach=False, single_hop=None):
@@ -898,7 +898,7 @@ class EphemeralOnionService(object):
 
         yield _add_ephemeral_service(config, onion, progress, version, None, await_all_uploads)
 
-        defer.returnValue(onion)
+        return onion
 
     def __init__(self, config, ports, hostname=None, private_key=None, version=3,
                  detach=False, await_all_uploads=None, single_hop=None, **kwarg):
@@ -1164,7 +1164,7 @@ class FilesystemAuthenticatedOnionService(object):
 
         yield config.save()
         yield uploaded[0]
-        defer.returnValue(fhs)
+        return fhs
 
     def __init__(self, config, thedir, ports, auth, version=3, group_readable=0):
         # XXX do we need version here? probably...
@@ -1389,7 +1389,7 @@ def _validate_ports(reactor, ports):
             processed_ports.append(
                 "{} 127.0.0.1:{}".format(remote, local)
             )
-    defer.returnValue(processed_ports)
+    return processed_ports
 
 
 def _validate_ports_low_level(ports):

--- a/txtorcon/router.py
+++ b/txtorcon/router.py
@@ -7,7 +7,7 @@ from .util import _Version
 from base64 import b64encode, b64decode
 from binascii import b2a_hex, a2b_hex
 
-from twisted.internet.defer import inlineCallbacks, returnValue, succeed
+from twisted.internet.defer import inlineCallbacks, succeed
 from twisted.python.deprecate import deprecated
 from twisted.web.client import readBody
 
@@ -215,7 +215,7 @@ class Router:
             raise RuntimeError(
                 'Expected "{}" but got data for "{}"'.format(self.id_hex, relay_data['fingerprint'])
             )
-        returnValue(relay_data)
+        return relay_data
 
     # note that exit-policy is no longer included in the
     # microdescriptors by default, so this stuff is mostly here as a

--- a/txtorcon/socks.py
+++ b/txtorcon/socks.py
@@ -7,7 +7,7 @@
 import struct
 from socket import inet_pton, inet_ntoa, inet_aton, AF_INET6, AF_INET
 
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, Deferred
 from twisted.internet.protocol import Protocol, Factory
 from twisted.internet.address import IPv4Address, IPv6Address, HostnameAddress
 from twisted.python.failure import Failure
@@ -650,7 +650,7 @@ def resolve(tor_endpoint, hostname):
     )
     proto = yield tor_endpoint.connect(factory)
     result = yield proto.when_done()
-    returnValue(result)
+    return result
 
 
 @inlineCallbacks
@@ -669,7 +669,7 @@ def resolve_ptr(tor_endpoint, ip):
     )
     proto = yield tor_endpoint.connect(factory)
     result = yield proto.when_done()
-    returnValue(result)
+    return result
 
 
 @implementer(IStreamClientEndpoint)
@@ -742,6 +742,6 @@ class TorSocksEndpoint(object):
         proto = yield proxy_ep.connect(socks_factory)
         wrapped_proto = yield proto.when_done()
         if self._tls:
-            returnValue(wrapped_proto.wrappedProtocol)
+            return wrapped_proto.wrappedProtocol
         else:
-            returnValue(wrapped_proto)
+            return wrapped_proto

--- a/txtorcon/testutil.py
+++ b/txtorcon/testutil.py
@@ -83,7 +83,7 @@ class FakeControlProtocol(object):
         text = yield self.get_info_raw(info)
         for line in text.split('\r\n'):
             cb(line)
-        defer.returnValue('')  # FIXME uh....what's up at torstate.py:350?
+        return ''  # FIXME uh....what's up at torstate.py:350?
 
     def get_conf(self, info):
         if len(self.answers) == 0:

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -59,7 +59,7 @@ def launch_tor(config, reactor,
         kill_on_stderr=kill_on_stderr,
         _tor_config=config,
     )
-    defer.returnValue(tor.process)
+    return tor.process
 
 
 class TorConfigType:
@@ -573,7 +573,7 @@ class TorConfig:
         """
         cfg = TorConfig(control=proto)
         yield cfg.post_bootstrap
-        defer.returnValue(cfg)
+        return cfg
 
     def __init__(self, control=None):
         self.config = {}
@@ -714,9 +714,7 @@ class TorConfig:
                         )
                     )
 
-        defer.returnValue(
-            _endpoint_from_socksport_line(reactor, socks_config)
-        )
+        return _endpoint_from_socksport_line(reactor, socks_config)
 
     # FIXME should re-name this to "tor_protocol" to be consistent
     # with other things? Or rename the other things?
@@ -1005,7 +1003,7 @@ class TorConfig:
         except TorProtocolError:
             # must be a version of Tor without config/defaults
             defaults = dict()
-        defer.returnValue(defaults)
+        return defaults
 
     @defer.inlineCallbacks
     def _do_setup(self, data):
@@ -1136,7 +1134,7 @@ class TorConfig:
                         )
                     )
             self.config['DetachedOnionServices'] = onions
-        defer.returnValue(self)
+        return self
 
     def _setup_hidden_services(self, servicelines):
 

--- a/txtorcon/torcontrolprotocol.py
+++ b/txtorcon/torcontrolprotocol.py
@@ -945,7 +945,7 @@ class TorControlProtocol(LineOnlyReceiver):
         yield self.queue_command('USEFEATURE EXTENDED_EVENTS')
 
         self.post_bootstrap.callback(self)
-        defer.returnValue(self)
+        return self
 
     # State Machine transitions and matchers. See the __init__ method
     # for a way to output a GraphViz dot diagram of the machine.

--- a/txtorcon/util.py
+++ b/txtorcon/util.py
@@ -299,7 +299,7 @@ def available_tcp_port(reactor):
     port = yield endpoint.listen(NoOpProtocolFactory())
     address = port.getHost()
     yield port.stopListening()
-    defer.returnValue(address.port)
+    return address.port
 
 
 def unescape_quoted_string(string):

--- a/txtorcon/web.py
+++ b/txtorcon/web.py
@@ -2,7 +2,7 @@
 
 from twisted.web.iweb import IAgentEndpointFactory
 from twisted.web.client import Agent, BrowserLikePolicyForHTTPS
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, Deferred
 from twisted.internet.endpoints import TCP4ClientEndpoint, UNIXClientEndpoint
 
 from zope.interface import implementer
@@ -162,12 +162,10 @@ def agent_for_socks_port(reactor, torconfig, socks_config, pool=None,
             port = int(socks_config)
         socks_ep = TCP4ClientEndpoint(reactor, host, port)
 
-    returnValue(
-        Agent.usingEndpointFactory(
-            reactor,
-            _AgentEndpointFactoryUsingTor(
-                reactor, socks_ep, tls_context_factory=tls_context_factory
-            ),
-            pool=pool,
-        )
+    return Agent.usingEndpointFactory(
+        reactor,
+        _AgentEndpointFactoryUsingTor(
+            reactor, socks_ep, tls_context_factory=tls_context_factory
+        ),
+        pool=pool,
     )


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.