### PR TITLE
feat(hidden-service): warn on unknown options

### DIFF
--- a/test/test_torconfig.py
+++ b/test/test_torconfig.py
@@ -1332,11 +1332,11 @@ HiddenServicePort=90 127.0.0.1:2345'''.format(fake0, fake1))
 
     def test_hidden_service_parse_error(self):
         conf = TorConfig(FakeControlProtocol(['config/names=']))
-        try:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             conf._setup_hidden_services('''FakeHiddenServiceKey=foo''')
-            self.fail()
-        except RuntimeError as e:
-            self.assertTrue('parse' in str(e))
+            self.assertEqual(len(w), 1)
+            self.assertTrue('unknown' in str(w[0].message).lower())
 
     def test_hidden_service_directory_absolute_path(self):
         conf = TorConfig(FakeControlProtocol(['config/names=']))

--- a/txtorcon/torconfig.py
+++ b/txtorcon/torconfig.py
@@ -1211,7 +1211,10 @@ class TorConfig:
                 group_read = int(v)
 
             else:
-                raise RuntimeError("Can't parse HiddenServiceOptions: " + k)
+                warnings.warn(
+                    "Ignoring unknown HiddenService option: {}={}".format(k, v),
+                    RuntimeWarning,
+                )
 
         maybe_add_hidden_service()
 


### PR DESCRIPTION
Updated the hidden service configuration to issue a warning for unknown options instead of raising a `RuntimeError`. This change improves error handling in the `TorConfig` class and updates the corresponding test to verify the warning behavior.