### PR TITLE
chore: remove unnecessary global declarations

### DIFF
--- a/test/test_util_imports.py
+++ b/test/test_util_imports.py
@@ -19,7 +19,6 @@ class TestImports(unittest.TestCase):
         Make sure we don't explode if there's no GeoIP module
         """
 
-        global __import__
         orig = __import__
         try:
             # attempt to ensure we've unimportted txtorcon.util
@@ -32,7 +31,6 @@ class TestImports(unittest.TestCase):
 
             # replace global import with our test import, which will
             # throw on GeoIP import no matter what
-            global __builtins__
             __builtins__['__import__'] = functools.partial(fake_import, orig)
 
             # now ensure we set up all the databases as "None" when we
@@ -44,4 +42,4 @@ class TestImports(unittest.TestCase):
             self.assertEqual(loc.countrycode, '')
 
         finally:
-            __import__ = orig
+            __builtins__['__import__'] = orig

--- a/txtorcon/endpoints.py
+++ b/txtorcon/endpoints.py
@@ -72,7 +72,6 @@ def get_global_tor_instance(reactor,
         is called. All calls to this method return the same instance.
     """
     global _global_tor
-    global _global_tor_lock
     yield _global_tor_lock.acquire()
 
     if _tor_launcher is None:


### PR DESCRIPTION
1. `test/test_util_imports.py`

  - remove unnecessary global `__builtins__` , only needed when assigning to a global name
  - remove invalid global `__import__` which is a built-in and can't be declared global

2. `txtorcon/endpoints.py`

  - remove unnecessary global `_global_tor_lock`, only needed when reassigning
  
  
Fixes `flake8` error raised in https://github.com/meejah/txtorcon/actions/runs/18819323063/job/53720940651?pr=407